### PR TITLE
Fix how max old space is set on node-red process

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -114,9 +114,7 @@ class Launcher {
         const appEnv = this.project.env
         const processArgs = [
             '-u',
-            this.projectDir,
-            '--max_old_space_size',
-            512
+            this.projectDir
         ]
 
         const processOptions = {
@@ -128,7 +126,11 @@ class Launcher {
 
         const execPathJS = path.join(this.projectDir, 'node_modules', 'node-red', 'red.js')
         const execPath = process.execPath
-        processArgs.unshift(execPathJS)
+        processArgs.unshift(
+            '--max_old_space_size=512',
+            execPathJS
+        )
+        debug(`CMD: ${execPath} ${processArgs.join(' ')}`)
         this.proc = childProcess.spawn(
             execPath,
             processArgs,


### PR DESCRIPTION
The args were being passed in on the end of the command, which caused them to get passed to Node-RED. They needed to be at the start of the arg list so they get passed to node.js.