### PR TITLE
Increase call-home timeout and avoid overlapping requests

### DIFF
--- a/lib/pinger.js
+++ b/lib/pinger.js
@@ -21,7 +21,7 @@ class Pinger {
                 authorization: `Bearer ${this.config.token}`
             },
             timeout: {
-                request: 1000
+                request: 10000
             }
         })
         this.projectFilePath = path.join(this.config.dir, PROJECT_FILE)
@@ -84,6 +84,7 @@ class Pinger {
             }
             info('Calling home')
             debug(JSON.stringify(payload, null, 2))
+            state.downloading = true
 
             this.client.post('live/state', {
                 json: payload
@@ -126,12 +127,18 @@ class Pinger {
                         }
                     } else if (err.response.statusCode === 404) {
                         warn('Unknown device. Shutting down')
+                        state.downloading = false
                         await this.stop(true)
                     } else if (err.response.statusCode === 401) {
                         warn('Invalid device credentials. Shutting down')
+                        state.downloading = false
                         await this.stop(true)
+                    } else {
+                        state.downloading = false
+                        warn(`Unexpected call home error: ${err.toString()}`)
                     }
                 } else {
+                    state.downloading = false
                     if (err.code === 'ECONNREFUSED') {
                         warn(`Unable to connect to ${state.config.forgeURL}`)
                     } else if (err.code === 'ETIMEDOUT') {


### PR DESCRIPTION
The existing call home timeout is just 1 second - fine for localhost, but less so for cloud hosted instances.

This PR increases the timeout to 15 seconds. It also ensures we don't send multiple requests when one is delayed beyond the interval.

It also adds error logging for a missing condition.