### PR TITLE
Let Agent NR listen on all interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+var/

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -2,7 +2,7 @@ const settings = require('./settings.json')
 
 module.exports = {
     flowFile: 'flows.json',
-    uiHost: '127.0.0.1',
+    uiHost: '0.0.0.0',
     uiPort: settings.port,
     httpAdminRoute: false,
     disableEditor: true,


### PR DESCRIPTION
Currently only listens on localhost, which is not much use.

Changes to listen on 0.0.0.0 for now, but should look at making
this configurable and checking IPv6


Fixes #7