### PR TITLE
logging: Poll messages moved from info to debug

### DIFF
--- a/lib/pinger.js
+++ b/lib/pinger.js
@@ -82,7 +82,7 @@ class Pinger {
                     snapshotRestartCount: this.launcher ? this.launcher.restartCount : 0
                 }
             }
-            info('Calling home')
+            debug('Calling home')
             debug(JSON.stringify(payload, null, 2))
             state.downloading = true
 
@@ -90,7 +90,7 @@ class Pinger {
                 json: payload
             }).then(async body => {
                 // all good
-                info('No updated needed')
+                debug('No updated needed')
                 if (!state.launcher && state.currentSnapshot) {
                     state.launcher = Launcher(state.config, state.currentSnapshot)
                     await state.launcher.start()
@@ -157,7 +157,7 @@ class Pinger {
                 state.launcher = undefined
             })
         } else {
-            info('Skipping call home whilst update in progress')
+            debug('Skipping call home whilst update in progress')
         }
     }
 


### PR DESCRIPTION
Some configurations persist log messages, and having 2 new lines in
30seconds creates churn on the disk, while the value is limited to
debugging of polling messages. This change allows a developer to debug
the same logic, but doesn't log by default on the info level.

Closes https://github.com/flowforge/flowforge-device-agent/issues/10