### PR TITLE
Add project-node support

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -183,7 +183,7 @@ class Agent {
                 // Nothing to update.
                 if (!this.launcher && this.currentSnapshot) {
                     // Ensure the launcher is running using the currentSnapshot
-                    this.launcher = launcher.Launcher(this.config, this.currentSnapshot, this.currentSettings)
+                    this.launcher = launcher.Launcher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings)
                     await this.launcher.start()
                     if (this.mqttClient) {
                         this.mqttClient.setProject(this.currentProject)
@@ -214,7 +214,7 @@ class Agent {
                         info(`Snapshot: ${this.currentSnapshot.id}`)
                         info(`Settings: ${this.currentSettings?.hash || 'none'}`)
                         await this.saveProject()
-                        this.launcher = launcher.Launcher(this.config, this.currentSnapshot, this.currentSettings)
+                        this.launcher = launcher.Launcher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings)
                         await this.launcher.writeConfiguration()
                         await this.launcher.start()
                         if (this.mqttClient) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,9 +18,10 @@ const packageJSONTemplate = {
 }
 
 class Launcher {
-    constructor (config, project, settings) {
+    constructor (config, project, snapshot, settings) {
         this.config = config
         this.project = project
+        this.snapshot = snapshot
         this.settings = settings
         this.restartCount = 0
         this.startTime = []
@@ -40,7 +41,8 @@ class Launcher {
     async writePackage () {
         debug(`Updating package.json: ${this.files.packageJSON}`)
         const packageJSON = JSON.parse(JSON.stringify(packageJSONTemplate))
-        packageJSON.dependencies = JSON.parse(JSON.stringify(this.project.modules))
+        packageJSON.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
+        packageJSON.dependencies['@flowforge/nr-project-nodes'] = '/Users/nol/code/flowforge/flowforge-nr-project-nodes'
         await fs.writeFile(this.files.packageJSON, JSON.stringify(packageJSON, ' ', 2))
     }
 
@@ -63,13 +65,13 @@ class Launcher {
 
     async writeFlow () {
         debug(`Updating flows file: ${this.files.flows}`)
-        const flows = JSON.stringify(this.project.flows)
+        const flows = JSON.stringify(this.snapshot.flows)
         return fs.writeFile(this.files.flows, flows)
     }
 
     async writeCredentials () {
         debug(`Updating credentials file: ${this.files.credentials}`)
-        const credentials = JSON.stringify(this.project.credentials || {})
+        const credentials = JSON.stringify(this.snapshot.credentials || {})
         return fs.writeFile(this.files.credentials, credentials)
     }
 
@@ -78,9 +80,29 @@ class Launcher {
         const templatePath = path.join(__dirname, './template/template-settings.js')
         await fs.copyFile(templatePath, this.files.settings)
 
+        let teamID
+        let projectLink
+        if (this.config.brokerUsername) {
+            // Parse the teamID out of the brokerUsername
+            teamID = this.config.brokerUsername.split(':')[1]
+            projectLink = {
+                token: this.config.token,
+                broker: {
+                    url: this.config.brokerURL,
+                    username: this.config.brokerUsername,
+                    password: this.config.brokerPassword
+                }
+            }
+        }
         const settings = {
             credentialSecret: this.config.credentialSecret,
-            port: this.config.port
+            port: this.config.port,
+            flowforge: {
+                forgeURL: this.config.forgeURL,
+                projectID: this.project || undefined,
+                teamID,
+                projectLink
+            }
         }
         await fs.writeFile(this.files.userSettings, JSON.stringify(settings))
     }
@@ -112,7 +134,7 @@ class Launcher {
             await this.writeSettings()
         }
 
-        const env = Object.assign({}, this.project.env)
+        const env = Object.assign({}, this.snapshot.env)
         if (this.settings?.env) {
             Object.assign(env, this.settings?.env)
         }
@@ -215,5 +237,5 @@ class Launcher {
 }
 
 module.exports = {
-    Launcher: (config, project, settings) => new Launcher(config, project, settings)
+    Launcher: (config, project, snapshot, settings) => new Launcher(config, project, snapshot, settings)
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -42,7 +42,6 @@ class Launcher {
         debug(`Updating package.json: ${this.files.packageJSON}`)
         const packageJSON = JSON.parse(JSON.stringify(packageJSONTemplate))
         packageJSON.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
-        packageJSON.dependencies['@flowforge/nr-project-nodes'] = '/Users/nol/code/flowforge/flowforge-nr-project-nodes'
         await fs.writeFile(this.files.packageJSON, JSON.stringify(packageJSON, ' ', 2))
     }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -15,5 +15,6 @@ module.exports = {
             allowInstall: true
         }
     },
-    credentialSecret: settings.credentialSecret
+    credentialSecret: settings.credentialSecret,
+    flowforge: settings.flowforge
 }

--- a/test/unit/lib/agent_spec.js
+++ b/test/unit/lib/agent_spec.js
@@ -276,7 +276,6 @@ describe('Agent', function () {
             agent.updating.should.be.false()
         })
 
-
         it('starts the launcher without update if needed', async function () {
             const agent = createHTTPAgent()
             agent.currentProject = 'projectId'


### PR DESCRIPTION
This ensures the necessary `flowforge.*` and `flowforge.projectLink.*` configuration is written to the device's settings file so that the Project Nodes will work.


As the nodes have not yet been published to npm, to test this PR requires adding a line to the launcher to inject a local path of where to install the nodes from.

It's hacky, but solves the chicken-vs-egg problem:

line 41 of `launcher.js`:
```
    async writePackage () {
        debug(`Updating package.json: ${this.files.packageJSON}`)
        const packageJSON = JSON.parse(JSON.stringify(packageJSONTemplate))
        packageJSON.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
        // ADD THIS ONE LINE - WITH THE PATH CHANGED TO YOUR LOCAL COPY OF THE NODES
        packageJSON.dependencies['@flowforge/nr-project-nodes'] = '/Users/nol/code/flowforge/flowforge-nr-project-nodes'
        await fs.writeFile(this.files.packageJSON, JSON.stringify(packageJSON, ' ', 2))
    }

```
