### PR TITLE
change log format

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,13 +1,13 @@
 
 let verbose = false
 function log (msg, level) {
-    console.log(`[${new Date().toISOString()}] ${level || 'INFO'}:`, msg)
+    console.log(`[AGENT] ${new Date().toLocaleString([],{ dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)
 }
 module.exports = {
     initLogger: configuration => { verbose = configuration.verbose },
-    info: msg => log(msg, 'INFO'),
-    warn: msg => log(msg, 'WARN'),
-    error: msg => log(msg, 'ERROR'),
-    debug: msg => verbose && log(msg, 'DEBUG'),
+    info: msg => log(msg, 'info'),
+    warn: msg => log(msg, 'warn'),
+    error: msg => log(msg, 'error'),
+    debug: msg => verbose && log(msg, 'debug'),
     log
 }


### PR DESCRIPTION
Makes the log format consistent with the Node-RED style,
Timestamps will now be in local time the same as Node-RED.
Adds an `[AGENT]` prefix to the log message to align with the `[NR] Prefix on Node-RED
Changes the log level text to lowercase the same as Node-RED
closes #30 