### PR TITLE
add jitter to mqtt and http checkin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
         "standard"
     ],
     "parserOptions": {
-        "ecmaVersion": 12
+         "ecmaVersion": 13
     },
     "rules": {
         "indent": ["error", 4]

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ MQTT options   | Description
 
 The following options can be added:
 
-Extra options | Description
---------------|---------------
-`interval`    | How often, in seconds, the agent checks in with the platform. Default: 60s
-`port`        | The port to listen on. Default: 1880
+Extra options   | Description
+----------------|---------------
+`interval`      | How often, in seconds, the agent checks in with the platform. Default: 60s
+`intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
+`port`          | The port to listen on. Default: 1880
 
 ## Running
 

--- a/lib/IntervalJitter.js
+++ b/lib/IntervalJitter.js
@@ -1,0 +1,99 @@
+const EventEmitter = require('events');
+/**
+ * An interval timer with jitter
+ * @example
+ * const j1 = new IntervalJitter()
+ * j1.start({interval: 1000, jitter: 100}, (t) => { console.log(`hello j1, this was delayed ${t}ms`) })
+ * setTimeout(() => { j1.stop() }, 5000)
+ * @example
+ * const j2 = new IntervalJitter()
+ * j2.on('interval', (t) => { console.log(`hello j2, this was delayed ${t}ms`) })
+ * j2.on('started', () => { console.log('j2 started') })
+ * j2.on('stopped', () => { console.log('j2 stopped') })
+ * // Start with initial "interval" firing at somewhere between 0 ~ 500ms
+ * // After that, fire somewhere between 900 ~ 1100ms
+ * j2.start({interval: 1000, jitter: 200, firstInterval: 0, firstJitter: 500})
+ * setTimeout(() => { j2.stop() }, 5000)
+ */
+class IntervalJitter extends EventEmitter {
+    constructor () {
+        super()
+        this.interval = 1000
+        this.jitter = 1000
+        this.firstInterval = null
+        this.firstJitter = null
+        this.callback = null
+        this.#init()
+    }
+    #stopped = true
+    #initTimer
+    #intervalTimer
+    #jitterTimer
+    #init() {
+        const self = this
+        self.on('internal:start1', (interval, jitter) => {
+            self.emit('started')
+            let firstDelay = interval + IntervalJitter.calculateJitter(jitter)
+            self.#initTimer = setTimeout(() => {
+                if (self.#stopped) { return }
+                self.callback && self.callback.call(this, firstDelay)
+                self.emit('interval', firstDelay)
+                self.lastTime = Date.now()
+                self.emit('internal:start2', self.interval, self.jitter)
+            }, firstDelay)
+        })
+        self.on('internal:start2', (interval, jitter) => {
+            if (self.#stopped) { return }
+            self.#intervalTimer = setInterval(() => {
+                if (self.#stopped) { return }
+                let variance = IntervalJitter.calculateJitter(jitter)
+                variance = variance < 0 ? 0 : variance
+                self.#jitterTimer = setTimeout(() => {
+                    if (self.#stopped) { return }
+                    const now = Date.now()
+                    self.callback && self.callback.call(this, now - self.lastTime)
+                    self.emit('interval', now - self.lastTime)
+                    self.lastTime = now
+                }, variance)
+            }, interval)
+        })
+    }
+    /** Calculate a jitter value between `0` ~ `jitter` */
+    static calculateJitter = (jitter) => {
+        if(typeof jitter !== 'number' || isNaN(jitter) || jitter < 0) { return 0 }
+        return Math.ceil(Math.random() * jitter)
+    }
+    get isRunning () {
+        return this.#stopped === false
+    }
+    /**
+    * Start the interval timer
+    * @param {object} options
+    * @param {number} options.interval - base/minimum delay
+    * @param {number} options.jitter - jitter to apply to `interval`
+    * @param {number} [options.firstInterval] - base delay for first interval (optional)
+    * @param {number} [options.firstJitter] - jitter to apply to `firstInterval` (optional)
+    * @param {function} [cb] - the function to call upon timeout (optional, can use `on('interval')`)
+    */
+    start ( {interval, jitter, firstInterval, firstJitter} = {}, callback) {
+        const self = this
+        if (!self.#stopped) { return }
+        if (typeof interval === 'number') { self.interval = interval }
+        if (typeof jitter === 'number') { self.jitter = jitter }
+        if (typeof firstInterval === 'number') { self.firstInterval = firstInterval }
+        if (typeof firstJitter === 'number') { self.firstJitter = firstJitter }
+        if (typeof callback === 'function') { self.callback = callback }
+        self.#stopped = false
+        this.emit('internal:start1', self.firstInterval, self.firstJitter)
+    }
+    /** Stop the interval timer */
+    stop () {
+        this.#stopped = true
+        clearInterval(this.#jitterTimer)
+        clearInterval(this.#intervalTimer)
+        clearInterval(this.#initTimer)
+        this.emit('stopped')
+    }
+}
+
+module.exports.IntervalJitter = IntervalJitter

--- a/lib/IntervalJitter.js
+++ b/lib/IntervalJitter.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events');
+const EventEmitter = require('events')
 /**
  * An interval timer with jitter
  * @example
@@ -25,15 +25,16 @@ class IntervalJitter extends EventEmitter {
         this.callback = null
         this.#init()
     }
+
     #stopped = true
     #initTimer
     #intervalTimer
     #jitterTimer
-    #init() {
+    #init () {
         const self = this
         self.on('internal:start1', (interval, jitter) => {
             self.emit('started')
-            let firstDelay = interval + IntervalJitter.calculateJitter(jitter)
+            const firstDelay = interval + IntervalJitter.calculateJitter(jitter)
             self.#initTimer = setTimeout(() => {
                 if (self.#stopped) { return }
                 self.callback && self.callback.call(this, firstDelay)
@@ -58,14 +59,17 @@ class IntervalJitter extends EventEmitter {
             }, interval)
         })
     }
+
     /** Calculate a jitter value between `0` ~ `jitter` */
     static calculateJitter = (jitter) => {
-        if(typeof jitter !== 'number' || isNaN(jitter) || jitter < 0) { return 0 }
+        if (typeof jitter !== 'number' || isNaN(jitter) || jitter < 0) { return 0 }
         return Math.ceil(Math.random() * jitter)
     }
+
     get isRunning () {
         return this.#stopped === false
     }
+
     /**
     * Start the interval timer
     * @param {object} options
@@ -75,7 +79,7 @@ class IntervalJitter extends EventEmitter {
     * @param {number} [options.firstJitter] - jitter to apply to `firstInterval` (optional)
     * @param {function} [cb] - the function to call upon timeout (optional, can use `on('interval')`)
     */
-    start ( {interval, jitter, firstInterval, firstJitter} = {}, callback) {
+    start ({ interval, jitter, firstInterval, firstJitter } = {}, callback) {
         const self = this
         if (!self.#stopped) { return }
         if (typeof interval === 'number') { self.interval = interval }
@@ -86,6 +90,7 @@ class IntervalJitter extends EventEmitter {
         self.#stopped = false
         this.emit('internal:start1', self.firstInterval, self.firstJitter)
     }
+
     /** Stop the interval timer */
     stop () {
         this.#stopped = true

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,10 +1,14 @@
 const got = require('got')
 const { info, warn, debug } = require('./log')
+const { IntervalJitter } = require('./IntervalJitter')
 
 class HTTPClient {
     constructor (agent, config) {
         this.agent = agent
         this.config = config
+        /** @type {IntervalJitter} */
+        this.heartbeat = new IntervalJitter()
+
         this.client = got.extend({
             prefixUrl: `${this.config.forgeURL}/api/v1/devices/${this.config.deviceId}/`,
             headers: {
@@ -36,19 +40,19 @@ class HTTPClient {
     }
 
     async startPolling () {
-        const period = this.config.interval || 60
-        info(`Starting http poll thread. Interval: ${period}s`)
-        this.interval = setInterval(() => {
+        const period = Math.ceil(this.config.interval || 60)
+        const jitter = Math.ceil(this.config.intervalJitter || 10)
+        info(`Starting http poll thread. Interval: ${period}s (±${jitter / 2}s)`)
+        // initial heartbeat to be operated between 0 ~ 500ms
+        this.heartbeat.start({ interval: period * 1000, jitter: jitter * 1000, firstInterval: 0, firstJitter: 500 }, () => {
             this.checkIn()
-        }, period * 1000)
-        this.checkIn()
+        })
     }
 
     async stopPolling () {
-        if (this.interval) {
+        if (this.heartbeat.isRunning()) {
             info('Stopping http poll thread')
-            clearInterval(this.interval)
-            this.interval = undefined
+            this.heartbeat.stop()
         }
     }
 

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -1,10 +1,13 @@
 const mqtt = require('mqtt')
 const { info, warn, debug } = require('./log')
+const { IntervalJitter } = require('./IntervalJitter')
 
 class MQTTClient {
     constructor (agent, config) {
         this.agent = agent
         this.config = config
+        /** @type {IntervalJitter} */
+        this.heartbeat = new IntervalJitter()
 
         const parts = /^device:(.*):(.*)$/.exec(config.brokerUsername)
         if (!parts) {
@@ -56,18 +59,19 @@ class MQTTClient {
         debug(`MQTT subscribe ${this.commandTopic}`)
         this.client.subscribe([this.commandTopic])
 
-        const period = this.config.interval || 60
-        info(`Starting heartbeat thread. Interval: ${period}s`)
-        this.interval = setInterval(() => {
+        const period = Math.ceil(this.config.interval || 60)
+        const jitter = Math.ceil(this.config.intervalJitter || 10)
+        info(`Starting heartbeat thread. Interval: ${period}s (±${jitter / 2}s)`)
+        // initial heartbeat to be operated at 255ms (±250ms)
+        this.heartbeat.start({ interval: period * 1000, jitter: jitter * 1000, firstInterval: 10, firstJitter: 500 }, () => {
             this.checkIn()
-        }, period * 1000)
+        })
     }
 
     stop () {
-        if (this.interval) {
+        if (this.heartbeat.isRunning()) {
             info('Stopping heartbeat thread')
-            clearInterval(this.interval)
-            this.interval = undefined
+            this.heartbeat.stop()
         }
         info('Closing MQTT connection')
         this.client.end()


### PR DESCRIPTION
fixes #23 

NOTES...

A new local class `IntervalJitter` was made to keep the logic changes in the main src to a minimum. By that I mean something capable of having an initial (lower) jittered delay (for 1st checkin) and then stable jitter centered around the desired "interval" +- jitter
 
Introducing jitter was surprisingly more difficult than I first envisioned - nothing in NPM suited my needs.  The majority of examples use this **nested timeout** pattern...
```js
    start () {
        this.stopped = false
        const runner = () => {
            // Stop if this jitter was stopped.
            if (this.stopped) { return }
            const interval = addJitter(this.#min, this.#max)
            this.intervalTimer = setTimeout(() => {
                if (this.stopped) { return }
                this.#callback && this.#callback(this)
                this.#loopTimer = setTimeout(runner, 1)  // << **** nested timeout ****
            }, interval)
        }
        runner()
    }
``` 

Where every call ends up adding to the stack and over the course of time, the delay is never centered around the set "interval" delay.  In tests, most aproaches around the web and in npm end up miles off course.

The included solution uses a unique pattern to avoid this.

For example, the below code ...
```js
const j1 = new IntervalJitter()
const timings = []
let first = true
j1.on('started', () => {
    console.log('started')
})
j1.on('interval', (t) => {
    if(!first) { timings.push(t) }
    console.log(`j1 @ ${t}ms`)
    first = false 
})
j1.on('stopped', () => {
    console.log('stopped')
    console.log('Minimum delay :', Math.min(...timings))
    console.log('Maximum delay :', Math.max(...timings))
    console.log('Average delay :', timings.reduce( ( a, b ) => a + b, 0 ) / timings.length)
    console.log('Total delay   :', timings.reduce((a, b) => a + b, 0))
})
j1.start({interval: 1000, jitter: 200, firstInterval: 10, firstJitter: 100})
setTimeout(() => {  j1.stop() }, 10100)
```

results in a jitter centered firmly around the desired "interval" **without** filling the stack with nested `setTimeouts`...
```log
started
j1 @ 18ms    << first delay is between 10 ~ 100ms as required
j1 @ 1007ms
j1 @ 1119ms
j1 @ 1062ms
j1 @ 1001ms
j1 @ 965ms
j1 @ 1033ms
j1 @ 920ms
j1 @ 1058ms
j1 @ 965ms
j1 @ 887ms   << subsequent delays all hover around 1000ms as requested
stopped
Minimum delay : 887ms
Maximum delay : 1119ms
Average delay : 1001.7ms
Total delay   : 10017ms
```


And the result of `interval: 50`, `jitter: 50` over 10 secs ...

```log
Minimum delay : 3
Maximum delay : 97
Average delay : 50.43434343434343
Total delay   : 9986
```

