### PR TITLE
Align cli comment with args.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,7 +10,7 @@ module.exports = {
         // Require dir to be created
         if (!fs.existsSync(options.dir)) {
             throw new Error(`Cannot find dir '${options.dir}'.
-Please ensure it exists and is writable, or set a different path with -u`)
+Please ensure it exists and is writable, or set a different path with -d`)
         }
 
         // Locate the config file. Either the path exactly as specified,


### PR DESCRIPTION
fixes #34

Upon launching device-agent (from another directory - deliberately) it states `Please ensure it exists and is writable, or set a different path with -u` but `args.js` expects `-d` or `--dir`

This PR updates the comment to say `..., or set a different path with -d`