### PR TITLE
Update eslint and include build GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Default Build & Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Run tests
+      run: npm run lint && npm run test

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,7 +1,7 @@
 
 let verbose = false
 function log (msg, level) {
-    console.log(`[AGENT] ${new Date().toLocaleString([],{ dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)
+    console.log(`[AGENT] ${new Date().toLocaleString([], { dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)
 }
 module.exports = {
     initLogger: configuration => { verbose = configuration.verbose },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     },
     "scripts": {
         "start": "node index.js",
+        "lint": "eslint -c .eslintrc \"*.js\" \"lib/**/*.js\" \"test/**/*.js\"",
+        "lint:fix": "eslint -c .eslintrc \"*.js\" \"lib/**/*.js\" \"test/**/*.js\" --fix",
         "test": "mocha test/unit/**/*_spec.js"
     },
     "bin": {
@@ -31,7 +33,7 @@
         "yaml": "^2.1.1"
     },
     "devDependencies": {
-        "eslint": "^8.20.0",
+        "eslint": "^8.25.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-node": "^11.1.0",
         "mocha": "^10.0.0",


### PR DESCRIPTION
Standardising on eslint/standard across all repos

This also adds the missing default gh action to run linting/tests.