### PR TITLE
Add "memory" and "persistent" as context stores

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -16,5 +16,10 @@ module.exports = {
         }
     },
     credentialSecret: settings.credentialSecret,
-    flowforge: settings.flowforge
+    flowforge: settings.flowforge,
+    contextStorage: {
+        default: 'memory',
+        memory: { module: 'memory' },
+        persistent: { module: 'localfilesystem' }
+    }
 }


### PR DESCRIPTION
part of flowforge/flowforge#212

Adds "memory" and "persistent" context storage entries to the device as agreed


Please update checklist here: https://github.com/flowforge/flowforge/issues/212#issuecomment-1342852768 once complete


NOTE: Implementing this here (as opposed to the settings.json generated for a device by forge) means the device agent must be updated before the context stores are realised.

