### PR TITLE
Support running on offline devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,21 +111,26 @@ Global Options
 By default the Device Agent will try and download the correct version of Node-RED and 
 any nodes required to run the Project Snapshot that is assigned to run on the device.
 
-If the device is being run on a offline network or security policies prevent the 
+If the device is being run on an offline network or security policies prevent the 
 Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
 set of modules.
 
 You can enable this mode by adding `-m` to the command line adding `moduleCache: true` 
 to the `device.yml` file. This will cause the Device Agent to load the modules from the 
-`module_cache` directory in the Device Agents Configuration directory as describe above.
+`module_cache` directory in the Device Agents Configuration directory as described above.
 By default this will be `/opt/flowforge-device/module_cache`.
 
-The easiest way to create the cache is to download the `package.json` for the Snapshot. 
-This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.
+### Creating a module cache
 
-Place this file in an empty directory on a machine with the same OS and architecture as 
-the device and run `npm install`. This will create a `node_modules` directory which you 
-should copy into `module_cache` director on the device.
+To create a suitable module cache, you will need to install the modules on a local device with
+access to npmjs.org, ensuring you use the same OS and Architecture as your target
+device, and then copy the modules on to your device.
+
+1. From the Project Snapshot page, select the snapshot you want to deploy and select the option to download its `package.json` file.
+2. Place this file in an empty directory on your local device.
+3. Run `npm install` to install the modules. This will create a `node_modules` directory.
+4. On your target device, create a directory called `module_cache` inside the Device Agent Configuration directory.
+5. Copy the `node_modules` directory from your local device to the target device so that it is under the `module_cache` directory.
 
 ## Running as a service
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot 
 
 Place this file in an empty directory on a machine with the same OS and architecture as 
 the device and run `npm install`. This will create a `node_modules` directory which you 
-copy to the device.
+should copy into `module_cache` director on the device.
 
 ## Running as a service
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options
   -d, --dir dir         Where the agent should store its state. Default: /opt/flowforge-device
   -i, --interval secs
   -p, --port number
+  -m, --moduleCache     use local npm module cache rather than install
 
 Global Options
 
@@ -114,9 +115,10 @@ If the device is being run on a offline network or security policies prevent the
 Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
 set of modules.
 
-You can enable this mode by adding `moduleCache: true` to the `device.yml` file. This will 
-cause the Device Agent to load the modules from the `module_cache` directory in the Device
-Agents Configuration directory as describe above. By default this will be `/opt/flowforge-device/module_cache`
+You can enable this mode by adding `-m` to the command line adding `moduleCache: true` 
+to the `device.yml` file. This will cause the Device Agent to load the modules from the 
+`module_cache` directory in the Device Agents Configuration directory as describe above.
+By default this will be `/opt/flowforge-device/module_cache`.
 
 The easiest way to create the cache is to download the `package.json` for the Snapshot. 
 This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Extra options   | Description
 `interval`      | How often, in seconds, the agent checks in with the platform. Default: 60s
 `intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
 `port`          | The port to listen on. Default: 1880
+`moduleCache`   | If the device can not access npmjs.org then use the node modules cache in `module_cache` directory. Default `false`
 
 ## Running
 
@@ -103,6 +104,26 @@ Global Options
   --version        print out version information
   -v, --verbose    turn on debugging output
 ```
+
+## Running with no access to npmjs.org
+
+By default the Device Agent will try and download the correct version of Node-RED and 
+any nodes required to run the Project Snapshot that is assigned to run on the device.
+
+If the device is being run on a offline network or security policies prevent the 
+Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
+set of modules.
+
+You can enable this mode by adding `moduleCache: true` to the `device.yml` file. This will 
+cause the Device Agent to load the modules from the `module_cache` directory in the Device
+Agents Configuration directory as describe above. By default this will be `/opt/flowforge-device/module_cache`
+
+The easiest way to create the cache is to download the `package.json` for the Snapshot. 
+This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.
+
+Place this file in an empty directory on a machine with the same OS and architecture as 
+the device and run `npm install`. This will create a `node_modules` directory which you 
+copy to the device.
 
 ## Running as a service
 

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -52,6 +52,13 @@ module.exports = [
         type: Boolean,
         alias: 'v',
         group: 'global'
+    },
+    {
+        name: 'moduleCache',
+        description: 'use local npm module cache rather than install',
+        type: Boolean,
+        alias: 'm',
+        group: 'main'
     }
 
 ]

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -50,7 +50,13 @@ class Launcher {
     async installDependencies () {
         info('Installing project dependencies')
         if (this.config.moduleCache) {
-            return fs.symlink(path.join(this.config.dir, 'module_cache/node_modules'), path.join(this.projectDir, 'node_modules'), 'dir')
+            const sourceDir = path.join(this.config.dir, 'module_cache/node_modules')
+            try {
+                await fs.access(sourceDir)
+            } catch (ee) {
+                return Promise.reject(ee)
+            }
+            return fs.symlink(sourceDir, path.join(this.projectDir, 'node_modules'), 'dir')
         } else {
             return new Promise((resolve, reject) => {
                 childProcess.exec('npm install --production', {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -49,19 +49,23 @@ class Launcher {
 
     async installDependencies () {
         info('Installing project dependencies')
-        return new Promise((resolve, reject) => {
-            childProcess.exec('npm install --production', {
-                cwd: this.projectDir
-            }, (error, stdout, stderr) => {
-                if (!error) {
-                    resolve()
-                } else {
-                    warn('Install failed')
-                    warn(stderr)
-                    reject(error)
-                }
+        if (this.config.moduleCache) {
+            return fs.symlink(path.join(this.config.dir, 'module_cache/node_modules'), path.join(this.projectDir, 'node_modules'), 'dir')
+        } else {
+            return new Promise((resolve, reject) => {
+                childProcess.exec('npm install --production', {
+                    cwd: this.projectDir
+                }, (error, stdout, stderr) => {
+                    if (!error) {
+                        resolve()
+                    } else {
+                        warn('Install failed')
+                        warn(stderr)
+                        reject(error)
+                    }
+                })
             })
-        })
+        }
     }
 
     async writeFlow () {


### PR DESCRIPTION
## Description

This allows Node-RED and nodes to be loaded from a local cache rather than being installed from npmjs.org each time the project snapshot is updated.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

part of #45

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

