### PR TITLE
Ensure ws URLs with ipv6 address can connect MQTT

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -1,6 +1,7 @@
 const mqtt = require('mqtt')
 const { info, warn, debug } = require('./log')
 const { IntervalJitter } = require('./IntervalJitter')
+const url = require('url')
 
 class MQTTClient {
     constructor (agent, config) {
@@ -30,7 +31,18 @@ class MQTTClient {
     }
 
     start () {
-        this.client = mqtt.connect(this.config.brokerURL, this.brokerConfig)
+        // PROBLEM: ipv6 ws addresses cannot connect
+        // INFO: Calling mqtt.connect('http://[::1]:8883') fails with error  ERR_INVALID_URL
+        // INFO: Calling mqtt.connect(new URL('http://[::1]:8883')) fails because `connect` only accepts a `string` or `url.parse` object
+        // INFO: Calling mqtt.connect(url.parse('http://[::1]:8883') fails because unlike new URL, url.parse drops the square brackets off hostname
+        //       (mqtt.js disassembles and reassembles the url using hostname + port so `ws://[::1]:8883` becomes `ws://::1:8883`)
+        // INFO: WS src code uses `new URL` so when `mqtt.js` passes the reassembled IP `http://::1:8883`, it fails with error ERR_INVALID_URL
+        // SEE: https://github.com/mqttjs/MQTT.js/issues/1569
+        const brokerURL = url.parse(this.config.brokerURL)
+        const _url = new URL(this.config.brokerURL)
+        brokerURL.hostname = _url.hostname
+        this.client = mqtt.connect(brokerURL, this.brokerConfig)
+
         this.client.on('connect', () => {
             this.client.publish(this.statusTopic, JSON.stringify(this.agent.getState()))
         })


### PR DESCRIPTION
## Description

Fix connection to IPv6 broker by passing in a parsed URL with the hostname restored to include square brackets

## Related Issue(s)

closes #50

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

