### PR TITLE
Docs: update project references to instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowForge Device Agent
 
-This module provides an agent that runs Node-RED projects deployed from the
+This module provides an agent that runs Node-RED instances deployed from the
 FlowForge platform.
 
 ## Prerequisites
@@ -138,7 +138,7 @@ Global Options
 ## Running with no access to npmjs.org
 
 By default the Device Agent will try and download the correct version of Node-RED and 
-any nodes required to run the Project Snapshot that is assigned to run on the device.
+any nodes required to run the Instance Snapshot that is assigned to run on the device.
 
 If the device is being run on an offline network or security policies prevent the 
 Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
@@ -155,7 +155,7 @@ To create a suitable module cache, you will need to install the modules on a loc
 access to npmjs.org, ensuring you use the same OS and Architecture as your target
 device, and then copy the modules on to your device.
 
-1. From the Project Snapshot page, select the snapshot you want to deploy and select the option to download its `package.json` file.
+1. From the Instance Snapshot page, select the snapshot you want to deploy and select the option to download its `package.json` file.
 2. Place this file in an empty directory on your local device.
 3. Run `npm install` to install the modules. This will create a `node_modules` directory.
 4. On your target device, create a directory called `module_cache` inside the Device Agent Configuration directory.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -45,7 +45,7 @@ class Agent {
                     this.currentSnapshot = config.snapshot || null
                     this.currentSettings = config.settings || null
                 }
-                info(`Project: ${this.currentProject || 'unknown'}`)
+                info(`Instance: ${this.currentProject || 'unknown'}`)
                 info(`Snapshot: ${this.currentSnapshot?.id || 'none'}`)
                 info(`Settings: ${this.currentSettings?.hash || 'none'}`)
             } catch (err) {
@@ -171,7 +171,7 @@ class Agent {
             let updateSnapshot = false
             let updateSettings = false
             if (Object.hasOwn(newState, 'project') && (!this.currentSnapshot || newState.project !== this.currentProject)) {
-                info('New project assigned')
+                info('New instance assigned')
                 this.currentProject = newState.project
                 // Update everything
                 updateSnapshot = true
@@ -217,7 +217,7 @@ class Agent {
                 if (this.currentSnapshot.id) {
                     try {
                         // There is a new snapshot/settings to use
-                        info(`Project: ${this.currentProject || 'unknown'}`)
+                        info(`Instance: ${this.currentProject || 'unknown'}`)
                         info(`Snapshot: ${this.currentSnapshot.id}`)
                         info(`Settings: ${this.currentSettings?.hash || 'none'}`)
                         await this.saveProject()
@@ -229,7 +229,7 @@ class Agent {
                             this.mqttClient.checkIn()
                         }
                     } catch (err) {
-                        warn(`Error whilst starting project: ${err.toString()}`)
+                        warn(`Error whilst starting Node-RED: ${err.toString()}`)
                         if (this.launcher) {
                             await this.launcher.stop(true)
                         }

--- a/lib/cli/usage.js
+++ b/lib/cli/usage.js
@@ -7,7 +7,7 @@ module.exports = {
         return commandLineUsage([
             {
                 header: 'FlowForge Device Agent',
-                content: `Run FlowForge projects on a device.\n\n Version: ${version}`
+                content: `Run FlowForge instances on a device.\n\n Version: ${version}`
             },
             {
                 header: 'Options',

--- a/lib/http.js
+++ b/lib/http.js
@@ -119,7 +119,7 @@ class HTTPClient {
                     warn(`Timeout trying to connect to ${this.config.forgeURL}`)
                 } else {
                     console.log(err)
-                    warn(`Error whilst starting project: ${err.toString()}`)
+                    warn(`Error whilst starting Node-RED: ${err.toString()}`)
                 }
             }
         })

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -53,7 +53,7 @@ class Launcher {
     }
 
     async installDependencies () {
-        info('Installing project dependencies')
+        info('Installing dependencies')
         if (this.config.moduleCache) {
             const sourceDir = path.join(this.config.dir, 'module_cache/node_modules')
             try {
@@ -124,7 +124,7 @@ class Launcher {
     }
 
     async writeConfiguration () {
-        info('Updating project configuration files')
+        info('Updating configuration files')
         await fs.mkdir(this.projectDir, { recursive: true })
         await this.writePackage()
         await this.installDependencies()
@@ -155,7 +155,7 @@ class Launcher {
             Object.assign(env, this.settings?.env)
         }
 
-        info('Starting project')
+        info('Starting Node-RED')
         const appEnv = env
         const processArgs = [
             '-u',
@@ -232,7 +232,7 @@ class Launcher {
     }
 
     async stop (clean) {
-        info('Stopping project')
+        info('Stopping Node-RED')
         // something wrong here, want to wait until child is dead
         if (this.proc) {
             this.shuttingDown = true
@@ -241,12 +241,12 @@ class Launcher {
             })
             this.proc.kill('SIGINT')
             await exitPromise
-            info('Stopped project')
+            info('Stopped Node-RED')
         }
         this.state = 'stopped'
 
         if (clean) {
-            info('Cleaning project directory')
+            info('Cleaning instance directory')
             await fs.rm(this.projectDir, { force: true, recursive: true })
         }
     }


### PR DESCRIPTION
Fixes #58 

This updates docs and log messages to remove references to 'projects'.

The agent still uses `projectId` when storing its local configuration.