### PR TITLE
Remove/recreate symlink to module_cache if exists

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -55,13 +55,20 @@ class Launcher {
     async installDependencies () {
         info('Installing project dependencies')
         if (this.config.moduleCache) {
+            info('Using module_cache')
             const sourceDir = path.join(this.config.dir, 'module_cache/node_modules')
+            const targetDir = path.join(this.projectDir, 'node_modules')
             try {
                 await fs.access(sourceDir)
             } catch (ee) {
                 return Promise.reject(ee)
             }
-            return fs.symlink(sourceDir, path.join(this.projectDir, 'node_modules'), 'dir')
+
+            if (existsSync(targetDir)) {
+                await fs.unlink(targetDir)
+            }
+
+            return fs.symlink(sourceDir, targetDir, 'dir')
         } else {
             return new Promise((resolve, reject) => {
                 childProcess.exec('npm install --production', {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -65,7 +65,7 @@ class Launcher {
             }
 
             if (existsSync(targetDir)) {
-                await fs.unlink(targetDir)
+                await fs.rm(targetDir, { force: true, recursive: true })
             }
 
             return fs.symlink(sourceDir, targetDir, 'dir')


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
If using the moduleCache:true option, then restarts fail because the symlink already exists. This change removes the link if it already exists and recreates it

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #62

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

