### PR TITLE
Allow the agent to start if initial checkin fails

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -15,6 +15,8 @@ class HTTPClient {
         /** @type {IntervalJitter} */
         this.heartbeat = new IntervalJitter()
 
+        this.completedInitialCheckin = false
+
         this.client = got.extend({
             prefixUrl: `${this.config.forgeURL}/api/v1/devices/${this.config.deviceId}/`,
             headers: {
@@ -80,7 +82,9 @@ class HTTPClient {
             }
             return
         }
-
+        if (!this.completedInitialCheckin) {
+            info('Connecting to FlowForge platform to verify device state')
+        }
         // If we're not in provisioning mode, post the state to the server
         debug('Calling home')
         debug(JSON.stringify(payload, null, 2))
@@ -96,6 +100,7 @@ class HTTPClient {
             })
         }).catch(async err => {
             if (err.response) {
+                this.completedInitialCheckin = true
                 if (err.response.statusCode === 409) {
                     const response = JSON.parse(err.response.body)
                     this.agent.setState({
@@ -114,12 +119,24 @@ class HTTPClient {
                 }
             } else {
                 if (err.code === 'ECONNREFUSED') {
-                    warn(`Unable to connect to ${this.config.forgeURL}`)
+                    warn(`Unable to connect to ${this.config.forgeURL}: connection refused`)
                 } else if (err.code === 'ETIMEDOUT') {
                     warn(`Timeout trying to connect to ${this.config.forgeURL}`)
+                } else if (err.code === 'EHOSTUNREACH') {
+                    warn(`Unable to connect to ${this.config.forgeURL}: network unreachable`)
                 } else {
-                    console.log(err)
                     warn(`Error whilst starting Node-RED: ${err.toString()}`)
+                    console.log(err)
+                }
+                if (!this.completedInitialCheckin) {
+                    // Allow the agent to start the existing project (if any)
+                    // having failed to do the initial checkin.
+                    this.completedInitialCheckin = true
+                    this.agent.setState({
+                        project: payload.project,
+                        snapshot: payload.snapshot,
+                        settings: payload.settings
+                    })
                 }
             }
         })

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -16,6 +16,9 @@ class MQTTClient {
         /** @type {IntervalJitter} */
         this.heartbeat = new IntervalJitter()
 
+        this.sentInitialCheckin = false
+        this.initialCheckinTimeout = null
+
         const parts = /^device:(.*):(.*)$/.exec(config.brokerUsername)
         if (!parts) {
             throw new Error('Invalid brokerUsername')
@@ -67,6 +70,10 @@ class MQTTClient {
             try {
                 const command = JSON.parse(payload)
                 if (command.command === 'update') {
+                    if (this.initialCheckinTimeout) {
+                        clearTimeout(this.initialCheckinTimeout)
+                        this.initialCheckinTimeout = null
+                    }
                     this.agent.setState(command)
                     return
                 }
@@ -101,6 +108,16 @@ class MQTTClient {
         if (!payload) {
             // No payload means we're busy updating - don't call home
             return
+        }
+        if (!this.sentInitialCheckin) {
+            this.initialCheckinTimeout = setTimeout(() => {
+                warn('Timeout performing initial check-in')
+                // Timeout the initial checkin - tell the agent to
+                // carry on with what it has already got
+                this.agent.setState(payload)
+                this.initialCheckinTimeout = null
+            }, 10000)
+            this.sentInitialCheckin = true
         }
         debug('Sending check-in message')
         this.client.publish(this.statusTopic, JSON.stringify(payload))


### PR DESCRIPTION
Fixes #61 

## Description

When starting up, the device agent calls home to check it is still allowed to run the existing configuration.

This was a choice we made to error on the side of ensuring the device is doing what it is allowed to do.

The feedback via #61 is that this is not desirable behaviour. It would be better to allow the device agent to start what it thinks is right until it knows otherwise.

This PR updates both the MQTT and HTTP status pingers so that if the initial checkin fails due to any failure to connect to the platform, the agent continues to start up.

The HTTP case is straight-forward as the initial HTTP request is works or fails.

The MQTT case was a bit more fiddly - it appears the mqtt client never tells us via any of the error handling that it has failed to establish its initial connection. Instead I've added a 10 second timeout after asking the client to send the initial check-in message.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

