### PR TITLE
Ensure settings are pulled for first snapshot

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -185,6 +185,9 @@ class Agent {
                     info('New settings available')
                     updateSettings = true
                 }
+                if (this.currentSettings === null) {
+                    updateSettings = true
+                }
             }
             if (!updateSnapshot && !updateSettings) {
                 // Nothing to update.


### PR DESCRIPTION


## Description

<!-- Describe your changes in detail -->
When a the first snapshot is assigned to a device it doesn't pull the settings until check-in after the deployment.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes flowforge/flowforge#1893

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

