### PR TITLE
Ensure cli usage errors are reported properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,14 +64,18 @@ info('----------------------')
 
 AgentManager.init(options)
 
-process.on('SIGINT', quit)
-process.on('SIGTERM', quit)
-process.on('SIGQUIT', quit)
+process.on('SIGINT', closeAgentAndQuit)
+process.on('SIGTERM', closeAgentAndQuit)
+process.on('SIGQUIT', closeAgentAndQuit)
 
 AgentManager.startAgent()
 
-async function quit (msg, errCode = 0) {
+async function closeAgentAndQuit (msg, errCode = 0) {
     if (AgentManager) { await AgentManager.close() }
+    quit(msg, errCode)
+}
+
+function quit (msg, errCode = 0) {
     if (msg) { console.log(msg) }
     process.exit(errCode)
 }


### PR DESCRIPTION
## Description

The work to add provisioning made the `quit` function async. By doing that it broke the handling of invalid cli args - because being async made the calling code to continue running beyond the point it would previously have exited synchronously.

This fixes it be restoring the synchronous flavour of the `quit` function and adding a separate async one for the specific case it is needed for.
