### PR TITLE
Do not setup checkin timeout if an update has already arrived

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -72,9 +72,10 @@ class MQTTClient {
             try {
                 const command = JSON.parse(payload)
                 if (command.command === 'update') {
-                    if (this.initialCheckinTimeout) {
+                    if (this.initialCheckinTimeout || !this.sentInitialCheckin) {
                         clearTimeout(this.initialCheckinTimeout)
                         this.initialCheckinTimeout = null
+                        this.sentInitialCheckin = true
                     }
                     this.agent.setState(command)
                     return


### PR DESCRIPTION
Fixes #69

## Description

The agent sets up the timeout *after* it has attempted to subscribe to the command topic. That means there is a timing window where a retained message could arrive before the timeout is setup. This could in turn lead to the timeout not being cleared (because the expected message arrived *before* the timeout existed).

This fix sets the sent flag to avoid setting up the timeout if a command has already arrived.
