### PR TITLE
Remote device access, editing and snapshotting with Auth enabled

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -154,14 +154,16 @@ class Agent {
         if (newState === null) {
             // The agent should not be running (bad credentials/device details)
             // Wipe the local configuration
-            this.stop()
-            this.currentSnapshot = null
-            this.currentProject = null
-            this.currentSettings = null
-            this.currentMode = null
-            await this.saveProject()
-            this.currentState = 'stopped'
-            this.updating = false
+            if (inhibitUpdates === false) {
+                this.stop()
+                this.currentSnapshot = null
+                this.currentProject = null
+                this.currentSettings = null
+                this.currentMode = null
+                await this.saveProject()
+                this.currentState = 'stopped'
+                this.updating = false
+            }
         } else if (inhibitUpdates === false && newState.project === null) {
             if (this.currentProject) {
                 debug('Removed from project')

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -88,7 +88,7 @@ class Agent {
     }
 
     async stop () {
-        this.httpClient.stopPolling()
+        await this.httpClient.stopPolling()
         if (this.mqttClient) {
             this.mqttClient.stop()
         }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -44,10 +44,12 @@ class Agent {
                     this.currentProject = config.project || null
                     this.currentSnapshot = config.snapshot || null
                     this.currentSettings = config.settings || null
+                    this.currentMode = config.mode || null
                 }
-                info(`Instance: ${this.currentProject || 'unknown'}`)
-                info(`Snapshot: ${this.currentSnapshot?.id || 'none'}`)
-                info(`Settings: ${this.currentSettings?.hash || 'none'}`)
+                info(`Instance      : ${this.currentProject || 'unknown'}`)
+                info(`Snapshot      : ${this.currentSnapshot?.id || 'none'}`)
+                info(`Settings      : ${this.currentSettings?.hash || 'none'}`)
+                info(`Operation Mode: ${this.currentMode || 'unknown'}`)
             } catch (err) {
                 warn(`Invalid project file: ${this.projectFilePath}`)
             }
@@ -58,7 +60,8 @@ class Agent {
         await fs.writeFile(this.projectFilePath, JSON.stringify({
             project: this.currentProject,
             snapshot: this.currentSnapshot,
-            settings: this.currentSettings
+            settings: this.currentSettings,
+            mode: this.currentMode
         }))
     }
 
@@ -93,6 +96,27 @@ class Agent {
         }
     }
 
+    async getCurrentPackage () {
+        if (this.launcher) {
+            return await this.launcher.readPackage()
+        }
+        return Promise.resolve(null)
+    }
+
+    async getCurrentFlows () {
+        if (this.launcher) {
+            return await this.launcher.readFlow()
+        }
+        return Promise.resolve(null)
+    }
+
+    async getCurrentCredentials () {
+        if (this.launcher) {
+            return await this.launcher.readCredentials()
+        }
+        return Promise.resolve(null)
+    }
+
     getState () {
         if (this.updating) {
             return null
@@ -102,6 +126,7 @@ class Agent {
             snapshot: this.currentSnapshot?.id || null,
             settings: this.currentSettings?.hash || null,
             state: this.launcher?.state || this.currentState,
+            mode: this.currentMode || 'autonomous',
             health: {
                 uptime: Math.floor((Date.now() - this.startTime) / 1000),
                 snapshotRestartCount: this.launcher?.restartCount || 0
@@ -117,6 +142,14 @@ class Agent {
             return
         }
         this.updating = true
+        if (newState !== null && newState.mode && newState.mode !== this.currentMode) {
+            // Device mode has been changed
+            // update the local state before processing the new state options
+            this.currentMode = newState.mode
+            await this.saveProject()
+        }
+        const inhibitUpdates = this.currentMode === 'developer'
+
         if (newState === null) {
             // The agent should not be running (bad credentials/device details)
             // Wipe the local configuration
@@ -124,10 +157,11 @@ class Agent {
             this.currentSnapshot = null
             this.currentProject = null
             this.currentSettings = null
+            this.currentMode = null
             await this.saveProject()
             this.currentState = 'stopped'
             this.updating = false
-        } else if (newState.project === null) {
+        } else if (inhibitUpdates === false && newState.project === null) {
             if (this.currentProject) {
                 debug('Removed from project')
             }
@@ -145,7 +179,7 @@ class Agent {
             await this.saveProject()
             this.currentState = 'stopped'
             this.updating = false
-        } else if (newState.snapshot === null) {
+        } else if (inhibitUpdates === false && newState.snapshot === null) {
             // Snapshot removed, but project still active
             if (this.currentSnapshot) {
                 debug('Active snapshot removed')
@@ -171,40 +205,43 @@ class Agent {
             // Check if any updates are needed
             let updateSnapshot = false
             let updateSettings = false
-            if (Object.hasOwn(newState, 'project') && (!this.currentSnapshot || newState.project !== this.currentProject)) {
-                info('New instance assigned')
-                this.currentProject = newState.project
-                // Update everything
-                updateSnapshot = true
-                updateSettings = true
-            } else {
-                if (Object.hasOwn(newState, 'snapshot') && (!this.currentSnapshot || newState.snapshot !== this.currentSnapshot.id)) {
-                    info('New snapshot available')
+            if (inhibitUpdates === false) {
+                if (Object.hasOwn(newState, 'project') && (!this.currentSnapshot || newState.project !== this.currentProject)) {
+                    info('New instance assigned')
+                    this.currentProject = newState.project
+                    // Update everything
                     updateSnapshot = true
-                }
-                if (Object.hasOwn(newState, 'settings') && (!this.currentSettings || newState.settings !== this.currentSettings?.hash)) {
-                    info('New settings available')
                     updateSettings = true
-                }
-                if (this.currentSettings === null) {
-                    updateSettings = true
+                } else {
+                    if (Object.hasOwn(newState, 'snapshot') && (!this.currentSnapshot || newState.snapshot !== this.currentSnapshot.id)) {
+                        info('New snapshot available')
+                        updateSnapshot = true
+                    }
+                    if (Object.hasOwn(newState, 'settings') && (!this.currentSettings || newState.settings !== this.currentSettings?.hash)) {
+                        info('New settings available')
+                        updateSettings = true
+                    }
+                    if (this.currentSettings === null) {
+                        updateSettings = true
+                    }
                 }
             }
             if (!updateSnapshot && !updateSettings) {
                 // Nothing to update.
+                // Start the launcher with the current config, Snapshot & settings
                 if (!this.launcher && this.currentSnapshot) {
-                    // Ensure the launcher is running using the currentSnapshot
                     this.launcher = launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings)
                     await this.launcher.start()
                     if (this.mqttClient) {
                         this.mqttClient.setProject(this.currentProject)
                         this.mqttClient.checkIn()
                     }
+                    this.currentState = 'stopped'
                 }
-                this.currentState = 'stopped'
                 this.updating = false
             } else {
-                // An update is needed. Stop the launcher if currently running
+                // An update is needed.
+                // Stop the launcher if currently running
                 this.currentState = 'updating'
                 if (this.launcher) {
                     info('Stopping current snapshot')

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -105,7 +105,8 @@ class Agent {
             health: {
                 uptime: Math.floor((Date.now() - this.startTime) / 1000),
                 snapshotRestartCount: this.launcher?.restartCount || 0
-            }
+            },
+            agentVersion: this.config.version
         }
     }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -233,7 +233,7 @@ class Agent {
                 // Nothing to update.
                 // Start the launcher with the current config, Snapshot & settings
                 if (!this.launcher && this.currentSnapshot) {
-                    this.launcher = launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings)
+                    this.launcher = launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                     await this.launcher.start()
                     if (this.mqttClient) {
                         this.mqttClient.setProject(this.currentProject)
@@ -265,7 +265,7 @@ class Agent {
                         info(`Snapshot: ${this.currentSnapshot.id}`)
                         info(`Settings: ${this.currentSettings?.hash || 'none'}`)
                         await this.saveProject()
-                        this.launcher = launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings)
+                        this.launcher = launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                         await this.launcher.writeConfiguration()
                         await this.launcher.start()
                         if (this.mqttClient) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -20,6 +20,7 @@ class Agent {
         this.currentSnapshot = null
         this.currentSettings = null
         this.currentProject = null
+        this.currentMode = null
         this.updating = false
         this.queuedUpdate = null
         // Track the local state of the agent. Start in 'unknown' state so

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,12 +1,35 @@
-const WebSocketClient = require('websocket').client
-// eslint-disable-next-line no-unused-vars
-const WebSocket = require('websocket')
+const WebSocket = require('ws')
 const got = require('got')
+
+function newWsConnection (url, /** @type {WebSocket.ClientOptions} */ options) {
+    if (options) {
+        return new WebSocket(url, options)
+    }
+    return new WebSocket(url)
+}
+
+async function isWsConnectionReady (ws) {
+    const connection = new Promise((resolve, reject) => {
+        const timer = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) {
+                clearInterval(timer)
+                resolve(true)
+            } else {
+                reject(new Error('Connection timeout'))
+            }
+        }, 200)
+    })
+    return connection
+}
 
 class EditorTunnel {
     constructor (config, options) {
-        this.client = new WebSocketClient()
+        // this.client = new WebSocketClientOLD()
+
         /** @type {Object.<string, WebSocket.client>} */
+
+        // this.client = new WebSocket()
+        /** @type {Object.<string, WebSocket>} */
         this.wsClients = {}
         this.deviceId = config.deviceId
         this.port = config.port
@@ -16,98 +39,6 @@ class EditorTunnel {
         const forgeURL = new URL(config.forgeURL)
         forgeURL.protocol = forgeURL.protocol === 'http:' ? 'ws:' : 'wss:'
         this.url = forgeURL.toString()
-
-        const tunnel = this
-
-        /** @type {WebSocket.connection} */
-        tunnel.connection = null
-
-        this.client.on('connect', connection => {
-            if (tunnel.connection) {
-                tunnel.connection.close()
-                tunnel.connection.removeAllListeners()
-                tunnel.connection = null
-            }
-            tunnel.connection = connection
-            connection.on('message', message => {
-                const request = JSON.parse(message.utf8Data)
-                if (request.ws) {
-                    if (request.id && tunnel.wsClients[request.id]) {
-                        tunnel.wsClients[request.id].send(request.body)
-                    } else {
-                        const tunnelledWSClient = new WebSocketClient()
-                        tunnelledWSClient.on('connect', (stream) => {
-                            stream.on('message', (msg) => {
-                                connection.send(JSON.stringify({
-                                    id: request.id,
-                                    ws: true,
-                                    body: msg.utf8Data
-                                }))
-                            })
-
-                            stream.on('close', () => {
-
-                            })
-                            tunnel.wsClients[request.id] = stream
-                        })
-                        tunnelledWSClient.on('connectFailed', (err) => {
-                            console.log(err)
-                        })
-                        tunnelledWSClient.connect(`ws://localhost:${tunnel.port}/device-editor${request.url}`)
-                    }
-                } else {
-                    // incoming request from the forge
-                    const reqHeaders = { ...request.headers }
-                    // add bearer token to the request headers
-                    if (tunnel.options.token) {
-                        reqHeaders['x-access-token'] = tunnel.options.token
-                    }
-                    // make request to the local device
-                    // add leading slash (if missing)
-                    const url = request.url.startsWith('/') ? request.url : `/${request.url || ''}`
-                    const fullUrl = `http://localhost:${tunnel.port}/device-editor${url}`
-                    // ↓ useful for debugging but very noisy
-                    // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
-                    got(fullUrl, {
-                        headers: reqHeaders,
-                        method: request.method,
-                        body: request.body,
-                        throwErrors: false
-                    }).then(response => {
-                        // send response back to the forge
-                        connection.send(JSON.stringify({
-                            id: request.id,
-                            headers: response.headers,
-                            body: response.rawBody,
-                            status: response.statusCode
-                        }))
-                    }).catch(_err => {
-                        // ↓ useful for debugging but noisy due to .map files
-                        // console.log(err)
-                        // console.log(JSON.stringify(request))
-                        connection.send(JSON.stringify({
-                            id: request.id,
-                            body: undefined,
-                            status: 404
-                        }))
-                    })
-                }
-            })
-
-            connection.on('error', (err) => {
-                console.log(err)
-            })
-
-            connection.on('close', () => {
-                Object.keys(tunnel.wsClients).forEach(c => {
-                    tunnel.wsClients[c].close()
-                })
-            })
-        })
-
-        this.client.on('connectFailed', err => {
-            console.log(err)
-        })
     }
 
     /**
@@ -123,35 +54,130 @@ class EditorTunnel {
         return new EditorTunnel(config, options)
     }
 
-    connect () {
-        // * Enable Device Editor (Step 8) - (device->forge:WS) Initiate WS connection (with token)
-        this.client.connect(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}/${this.options.token}`, null, null, {
-            'x-access-token': this.options.token
+    async connect () {
+        const thisTunnel = this
+        if (this.socket) {
+            this.close()
+        }
+
+        const socket = newWsConnection(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}/${this.options.token}`, {
+            headers: {
+                'x-access-token': this.options.token
+            }
         })
-        return true
+        socket.onopen = (evt) => {
+            console.log('socket.onopen')
+            socket.on('message', async (message) => {
+                // a message from the editor
+                const request = JSON.parse(message.toString('utf-8'))
+                if (request.ws) {
+                    if (request.id && thisTunnel.wsClients[request.id] && thisTunnel.wsClients[request.id].readyState !== WebSocket.OPEN) {
+                        thisTunnel.wsClients[request.id].close()
+                        thisTunnel.wsClients[request.id] = null
+                        // short delay to allow the socket to close and stack to unwind
+                        await new Promise((resolve) => setTimeout(resolve, 1))
+                    }
+                    if (request.id && thisTunnel.wsClients[request.id] && thisTunnel.wsClients[request.id]?.readyState === WebSocket.OPEN) {
+                        thisTunnel.wsClients[request.id].send(request.body)
+                    } else {
+                        const tunnelledWSClient = newWsConnection(`ws://localhost:${thisTunnel.port}/device-editor${request.url}`)
+                        tunnelledWSClient._id = request.id // for debugging and tracking
+                        tunnelledWSClient.on('open', () => {
+                            console.log('tunnelledWSClient.onopen')
+                            tunnelledWSClient.on('message', (data) => {
+                                const sendData = {
+                                    id: request.id,
+                                    ws: true,
+                                    body: data.toString('utf-8')
+                                }
+                                socket.send(JSON.stringify(sendData))
+                            })
+                            thisTunnel.wsClients[request.id] = tunnelledWSClient
+                            // tunnelledWSClient.send(JSON.stringify(request)) // TODO: send the request body sent initially?
+                        })
+                        tunnelledWSClient.on('close', (code, reason) => {
+                            console.warn('tunnelledWSClient.onclose', code)
+                            thisTunnel.wsClients[request.id]?.removeAllListeners()
+                            thisTunnel.wsClients[request.id] = null
+                        })
+                        tunnelledWSClient.on('error', (err) => {
+                            console.error(err)
+                            thisTunnel.wsClients[request.id]?.close(1006, err.message)
+                            thisTunnel.wsClients[request.id] = null
+                        })
+                        // await isWsConnectionReady(tunnelledWSClient) // unreliable
+                    }
+                } else {
+                    const reqHeaders = { ...request.headers }
+                    // add bearer token to the request headers
+                    if (thisTunnel.options.token) {
+                        reqHeaders['x-access-token'] = thisTunnel.options.token
+                    }
+                    // make request to the local device
+                    // add leading slash (if missing)
+                    const url = request.url.startsWith('/') ? request.url : `/${request.url || ''}`
+                    const fullUrl = `http://localhost:${thisTunnel.port}/device-editor${url}`
+                    // ↓ useful for debugging but very noisy
+                    // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
+                    got(fullUrl, {
+                        headers: reqHeaders,
+                        method: request.method,
+                        body: request.body,
+                        throwErrors: false
+                    }).then(response => {
+                        // send response back to the forge
+                        socket.send(JSON.stringify({
+                            id: request.id,
+                            headers: response.headers,
+                            body: response.rawBody,
+                            status: response.statusCode
+                        }))
+                    }).catch(_err => {
+                        // ↓ useful for debugging but noisy due to .map files
+                        // console.log(err)
+                        // console.log(JSON.stringify(request))
+                        socket.send(JSON.stringify({
+                            id: request.id,
+                            body: undefined,
+                            status: 404
+                        }))
+                    })
+                }
+            })
+        }
+        socket.on('close', (code, reason) => {
+            console.warn('socket.close', code, reason)
+            this.close(code, reason)
+        })
+        socket.on('error', (err) => {
+            console.warn('socket.error', err)
+            this.close(1006, err.message) // 1006 = Abnormal Closure
+        })
+        this.socket = socket
+        return !!(await isWsConnectionReady(this.socket))
     }
 
-    close () {
-        this.client?.abort()
+    close (code, reason) {
+        code = code || 1000
+        reason = reason || 'Normal Closure'
         // loop through each ws client and close its connection
-        Object.keys(this.wsClients).forEach(c => {
-            this.wsClients[c].removeAllListeners()
-            this.wsClients[c].close()
+        Object.keys(this.wsClients || {}).forEach(c => {
+            this.wsClients[c]?.close()
             delete this.wsClients[c]
         })
 
-        // close the tunnel connection
-        if (this.connection) {
-            this.connection.close()
-            this.connection.removeAllListeners()
-            this.connection = null
+        // // close the tunnel connection
+        // if (this.connection) {
+        //     this.connection.close()
+        //     this.connection.removeAllListeners()
+        //     this.connection = null
+        // }
+        // close the socket
+        if (this.socket) {
+            this.socket.close()
+            this.socket.removeAllListeners()
         }
-        if (this.client?.socket) {
-            this.client.socket.end()
-            this.client.socket.removeAllListeners()
-            this.client?.socket?.destroy()
-        }
-        this.client = null
+        this.socket = null
     }
 }
 

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -59,7 +59,7 @@ class EditorTunnel {
         if (this.socket) {
             this.close()
         }
-
+        // * Enable Device Editor (Step 8) - (device->forge:WS) Initiate WS connection (with token)
         const socket = newWsConnection(`${this.url}api/v1/devices/${this.deviceId}/editor/comms/${this.options.token}`, {
             headers: {
                 'x-access-token': this.options.token

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,13 +1,17 @@
 const WebSocketClient = require('websocket').client
+// eslint-disable-next-line no-unused-vars
+const WebSocket = require('websocket')
 const got = require('got')
 
 class EditorTunnel {
-    constructor (config) {
+    constructor (config, options) {
         this.client = new WebSocketClient()
+        /** @type {Object.<string, WebSocket.client>} */
         this.wsClients = {}
         this.deviceId = config.deviceId
         this.port = config.port
         this.config = config
+        this.options = options || {}
 
         const forgeURL = new URL(config.forgeURL)
         forgeURL.protocol = forgeURL.protocol === 'http:' ? 'ws:' : 'wss:'
@@ -15,7 +19,16 @@ class EditorTunnel {
 
         const tunnel = this
 
+        /** @type {WebSocket.connection} */
+        tunnel.connection = null
+
         this.client.on('connect', connection => {
+            if (tunnel.connection) {
+                tunnel.connection.close()
+                tunnel.connection.removeAllListeners()
+                tunnel.connection = null
+            }
+            tunnel.connection = connection
             connection.on('message', message => {
                 const request = JSON.parse(message.utf8Data)
                 if (request.ws) {
@@ -23,8 +36,8 @@ class EditorTunnel {
                         tunnel.wsClients[request.id].send(request.body)
                     } else {
                         const tunnelledWSClient = new WebSocketClient()
-                        tunnelledWSClient.on('connect', (conn) => {
-                            conn.on('message', (msg) => {
+                        tunnelledWSClient.on('connect', (stream) => {
+                            stream.on('message', (msg) => {
                                 connection.send(JSON.stringify({
                                     id: request.id,
                                     ws: true,
@@ -32,30 +45,46 @@ class EditorTunnel {
                                 }))
                             })
 
-                            conn.on('close', () => {
+                            stream.on('close', () => {
 
                             })
-                            tunnel.wsClients[request.id] = conn
+                            tunnel.wsClients[request.id] = stream
                         })
-                        tunnelledWSClient.connect(`ws://localhost:${tunnel.port}${request.url}`)
+                        tunnelledWSClient.on('connectFailed', (err) => {
+                            console.log(err)
+                        })
+                        tunnelledWSClient.connect(`ws://localhost:${tunnel.port}/device-editor${request.url}`)
                     }
                 } else {
-                    console.log(`http://localhost:${tunnel.port}${request.url}`)
-                    got(`http://localhost:${tunnel.port}${request.url}`, {
-                        headers: request.headers,
+                    // incoming request from the forge
+                    const reqHeaders = { ...request.headers }
+                    // add bearer token to the request headers
+                    if (tunnel.options.token) {
+                        reqHeaders['x-access-token'] = tunnel.options.token
+                    }
+                    // make request to the local device
+                    // add leading slash (if missing)
+                    const url = request.url.startsWith('/') ? request.url : `/${request.url || ''}`
+                    const fullUrl = `http://localhost:${tunnel.port}/device-editor${url}`
+                    // ↓ useful for debugging but very noisy
+                    // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
+                    got(fullUrl, {
+                        headers: reqHeaders,
                         method: request.method,
                         body: request.body,
                         throwErrors: false
                     }).then(response => {
+                        // send response back to the forge
                         connection.send(JSON.stringify({
                             id: request.id,
                             headers: response.headers,
                             body: response.rawBody,
                             status: response.statusCode
                         }))
-                    }).catch(err => {
-                        console.log(err)
-                        console.log(JSON.stringify(request))
+                    }).catch(_err => {
+                        // ↓ useful for debugging but noisy due to .map files
+                        // console.log(err)
+                        // console.log(JSON.stringify(request))
                         connection.send(JSON.stringify({
                             id: request.id,
                             body: undefined,
@@ -81,14 +110,49 @@ class EditorTunnel {
         })
     }
 
+    /**
+     * Create a tunnel instance
+     * @param {Object} config tunnel configuration
+     * @param {string} config.deviceId device id
+     * @param {string} config.token device token
+     * @param {string} config.forgeURL forge URL
+     * @param {number} config.port port to tunnel to
+     * @returns {EditorTunnel} tunnel instance
+     */
+    static create (config, options) {
+        return new EditorTunnel(config, options)
+    }
+
     connect () {
-        this.client.connect(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}`, null, {
-            Authorization: `Bearer: ${this.config.token}`
+        // * Enable Device Editor (Step 8) - (device->forge:WS) Initiate WS connection (with token)
+        this.client.connect(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}/${this.options.token}`, null, null, {
+            'x-access-token': this.options.token
         })
+        return true
+    }
+
+    close () {
+        this.client?.abort()
+        // loop through each ws client and close its connection
+        Object.keys(this.wsClients).forEach(c => {
+            this.wsClients[c].removeAllListeners()
+            this.wsClients[c].close()
+            delete this.wsClients[c]
+        })
+
+        // close the tunnel connection
+        if (this.connection) {
+            this.connection.close()
+            this.connection.removeAllListeners()
+            this.connection = null
+        }
+        if (this.client?.socket) {
+            this.client.socket.end()
+            this.client.socket.removeAllListeners()
+            this.client?.socket?.destroy()
+        }
+        this.client = null
     }
 }
 
-module.exports = {
-    newEditorTunnel: (config) => new EditorTunnel(config),
-    EditorTunnel
-}
+module.exports = EditorTunnel

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,0 +1,94 @@
+const WebSocketClient = require('websocket').client
+const got = require('got')
+
+class EditorTunnel {
+    constructor (config) {
+        this.client = new WebSocketClient()
+        this.wsClients = {}
+        this.deviceId = config.deviceId
+        this.port = config.port
+        this.config = config
+
+        const forgeURL = new URL(config.forgeURL)
+        forgeURL.protocol = forgeURL.protocol === 'http:' ? 'ws:' : 'wss:'
+        this.url = forgeURL.toString()
+
+        const tunnel = this
+
+        this.client.on('connect', connection => {
+            connection.on('message', message => {
+                const request = JSON.parse(message.utf8Data)
+                if (request.ws) {
+                    if (request.id && tunnel.wsClients[request.id]) {
+                        tunnel.wsClients[request.id].send(request.body)
+                    } else {
+                        const tunnelledWSClient = new WebSocketClient()
+                        tunnelledWSClient.on('connect', (conn) => {
+                            conn.on('message', (msg) => {
+                                connection.send(JSON.stringify({
+                                    id: request.id,
+                                    ws: true,
+                                    body: msg.utf8Data
+                                }))
+                            })
+
+                            conn.on('close', () => {
+
+                            })
+                            tunnel.wsClients[request.id] = conn
+                        })
+                        tunnelledWSClient.connect(`ws://localhost:${tunnel.port}${request.url}`)
+                    }
+                } else {
+                    console.log(`http://localhost:${tunnel.port}${request.url}`)
+                    got(`http://localhost:${tunnel.port}${request.url}`, {
+                        headers: request.headers,
+                        method: request.method,
+                        body: request.body,
+                        throwErrors: false
+                    }).then(response => {
+                        connection.send(JSON.stringify({
+                            id: request.id,
+                            headers: response.headers,
+                            body: response.rawBody,
+                            status: response.statusCode
+                        }))
+                    }).catch(err => {
+                        console.log(err)
+                        console.log(JSON.stringify(request))
+                        connection.send(JSON.stringify({
+                            id: request.id,
+                            body: undefined,
+                            status: 404
+                        }))
+                    })
+                }
+            })
+
+            connection.on('error', (err) => {
+                console.log(err)
+            })
+
+            connection.on('close', () => {
+                Object.keys(tunnel.wsClients).forEach(c => {
+                    tunnel.wsClients[c].close()
+                })
+            })
+        })
+
+        this.client.on('connectFailed', err => {
+            console.log(err)
+        })
+    }
+
+    connect () {
+        this.client.connect(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}`, null, {
+            Authorization: `Bearer: ${this.config.token}`
+        })
+    }
+}
+
+module.exports = {
+    newEditorTunnel: (config) => new EditorTunnel(config),
+    EditorTunnel
+}

--- a/lib/http.js
+++ b/lib/http.js
@@ -96,7 +96,8 @@ class HTTPClient {
             this.agent.setState({
                 project: payload.project,
                 snapshot: payload.snapshot,
-                settings: payload.settings
+                settings: payload.settings,
+                mode: payload.mode
             })
         }).catch(async err => {
             if (err.response) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -40,16 +40,37 @@ class Launcher {
 
     async writePackage () {
         debug(`Updating package.json: ${this.files.packageJSON}`)
-        const packageJSON = JSON.parse(JSON.stringify(packageJSONTemplate))
-        packageJSON.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
-        packageJSON.version = `0.0.0-${this.snapshot.id}`
-        packageJSON.name = this.snapshot.env.FF_PROJECT_NAME
+        const packageData = JSON.parse(JSON.stringify(packageJSONTemplate))
+        packageData.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
+        packageData.version = `0.0.0-${this.snapshot.id}`
+        packageData.name = this.snapshot.env.FF_PROJECT_NAME
         if (this.snapshot.name && this.snapshot.description) {
-            packageJSON.description = `${this.snapshot.name} - ${this.snapshot.description}`
+            packageData.description = `${this.snapshot.name} - ${this.snapshot.description}`
         }
-        await fs.writeFile(this.files.packageJSON, JSON.stringify(packageJSON, ' ', 2))
+        await fs.writeFile(this.files.packageJSON, JSON.stringify(packageData, ' ', 2))
         await fs.rm(path.join(this.projectDir, '.config.nodes.json'), { force: true })
         await fs.rm(path.join(this.projectDir, '.config.nodes.json.backup'), { force: true })
+    }
+
+    async readPackage () {
+        debug(`Reading package.json: ${this.files.packageJSON}`)
+        const data = {
+            modules: {},
+            version: '',
+            name: '',
+            description: ''
+        }
+        try {
+            const packageJSON = await fs.readFile(this.files.packageJSON)
+            const packageData = JSON.parse(packageJSON)
+            data.modules = packageData.dependencies
+            data.version = packageData.version
+            data.name = packageData.name
+            data.description = packageData.descriptions
+        } catch (e) {
+            console.error(e)
+        }
+        return data
     }
 
     async installDependencies () {
@@ -92,10 +113,22 @@ class Launcher {
         return fs.writeFile(this.files.flows, flows)
     }
 
+    async readFlow () {
+        debug(`Reading flows file: ${this.files.flows}`)
+        const flows = await fs.readFile(this.files.flows, 'utf8')
+        return JSON.parse(flows)
+    }
+
     async writeCredentials () {
         debug(`Updating credentials file: ${this.files.credentials}`)
         const credentials = JSON.stringify(this.snapshot.credentials || {})
         return fs.writeFile(this.files.credentials, credentials)
+    }
+
+    async readCredentials () {
+        debug(`Reading credentials file: ${this.files.flows}`)
+        const creds = await fs.readFile(this.files.credentials, 'utf8')
+        return JSON.parse(creds)
     }
 
     async writeSettings () {
@@ -120,6 +153,16 @@ class Launcher {
         const settings = {
             credentialSecret: this.config.credentialSecret,
             port: this.config.port,
+            codeEditor: this.settings?.codeEditor || 'monaco',
+            'forge-light': { launcherVersion: this.config.version, forgeURL: this.config.forgeURL, projectURL: `${this.config.forgeURL}/device/${this.config.deviceId}/overview` },
+            editorTheme: {
+                theme: 'forge-light', // TODO: get from forge platform. MVP - set to forge-light
+                codeEditor: {
+                    lib: 'monaco' // TODO: get from forge platform. MVP - set to monaco
+                },
+                // library: TODO
+                tours: false
+            },
             flowforge: {
                 forgeURL: this.config.forgeURL,
                 projectID: this.project || undefined,

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,11 +18,12 @@ const packageJSONTemplate = {
 }
 
 class Launcher {
-    constructor (config, project, snapshot, settings) {
+    constructor (config, project, snapshot, settings, mode) {
         this.config = config
         this.project = project
         this.snapshot = snapshot
         this.settings = settings
+        this.mode = mode
         this.restartCount = 0
         this.startTime = []
         this.state = 'stopped'
@@ -304,6 +305,6 @@ class Launcher {
 }
 
 module.exports = {
-    newLauncher: (config, project, snapshot, settings) => new Launcher(config, project, snapshot, settings),
+    newLauncher: (config, project, snapshot, settings, mode) => new Launcher(config, project, snapshot, settings, mode),
     Launcher
 }

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -2,6 +2,7 @@ const mqtt = require('mqtt')
 const { info, warn, debug, setMQTT, getBufferedMessages } = require('./logging/log')
 const { IntervalJitter } = require('./IntervalJitter')
 const url = require('url')
+const tunnel = require('./editor/tunnel')
 
 class MQTTClient {
     /**
@@ -87,9 +88,17 @@ class MQTTClient {
                 } else if (command.command === 'stopLog') {
                     this.logEnabled = false
                     return
+                } else if (command.command === 'startEditor') {
+                    info('starting Editor access')
+                    tunnel.newEditorTunnel(this.config).connect()
+                    return
+                } else if (command.command === 'stopEditor') {
+                    info('stopping Editor access')
+                    return
                 }
-                warn(`Invalid command type received from platform: ${command}`)
+                warn(`Invalid command type received from platform: ${command.command}`)
             } catch (err) {
+                warn(err)
                 warn(`Invalid command payload received from platform: ${payload}`)
             }
         })

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -73,57 +73,59 @@ class MQTTClient {
 
         this.client.on('message', async (topic, message, packet) => {
             debug(`Command from ${topic}`)
-            const payload = message.toString()
+            const _message = message.toString()
             try {
-                const command = JSON.parse(payload)
-                if (command.command === 'update') {
+                const msg = JSON.parse(_message)
+                if (msg.command === 'update') {
                     if (this.initialCheckinTimeout) {
                         clearTimeout(this.initialCheckinTimeout)
                         this.initialCheckinTimeout = null
                     }
-                    this.agent.setState(command)
+                    this.agent.setState(msg)
                     return
-                } else if (command.command === 'startLog') {
+                } else if (msg.command === 'startLog') {
                     if (!this.logEnabled) {
                         this.client.publish(this.logTopic, JSON.stringify(getBufferedMessages()))
                     }
                     this.logEnabled = true
                     return
-                } else if (command.command === 'stopLog') {
+                } else if (msg.command === 'stopLog') {
                     this.logEnabled = false
                     return
-                } else if (command.command === 'startEditor') {
+                } else if (msg.command === 'startEditor') {
                     info('starting Editor access')
                     if (this.tunnel) {
                         this.tunnel.close()
                         this.tunnel = null
                     }
                     // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
-                    this.tunnel = EditorTunnel.create(this.config, { token: command?.payload?.token })
+                    console.log('creating tunnel', this.config, msg)
+                    this.tunnel = EditorTunnel.create(this.config, { token: msg?.payload?.token })
                     // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
-                    const result = this.tunnel.connect()
+                    const result = await this.tunnel.connect()
                     // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
-                    this.sendCommandResponse(command, { connected: result, token: command?.payload?.token })
+                    console.log('sending response', { connected: result, token: msg?.payload?.token })
+                    this.sendCommandResponse(msg, { connected: result, token: msg?.payload?.token })
                     this.sendStatus()
                     return
-                } else if (command.command === 'stopEditor') {
+                } else if (msg.command === 'stopEditor') {
                     info('stopping Editor access')
                     if (this.tunnel) {
                         this.tunnel.close()
                         this.tunnel = null
                     }
                     return
-                } else if (command.command === 'upload') {
+                } else if (msg.command === 'upload') {
                     info('performing upload')
                     // upload expects a response. get the data and send it back
                     const response = await this.getUploadData()
-                    this.sendCommandResponse(command, response)
+                    this.sendCommandResponse(msg, response)
                     return
                 }
-                warn(`Invalid command type received from platform: ${command.command}`)
+                warn(`Invalid command type received from platform: ${msg.command}`)
             } catch (err) {
                 warn(err)
-                warn(`Invalid command payload received from platform: ${payload}`)
+                warn(`Invalid command message received from platform: ${_message}`)
             }
         })
         debug(`MQTT subscribe ${this.commandTopic}`)
@@ -145,7 +147,7 @@ class MQTTClient {
         }
         info('Closing MQTT connection')
         setMQTT(undefined)
-        this.client.end()
+        this.client && this.client.end()
     }
 
     checkIn () {

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -2,7 +2,7 @@ const mqtt = require('mqtt')
 const { info, warn, debug, setMQTT, getBufferedMessages } = require('./logging/log')
 const { IntervalJitter } = require('./IntervalJitter')
 const url = require('url')
-const tunnel = require('./editor/tunnel')
+const EditorTunnel = require('./editor/tunnel')
 
 class MQTTClient {
     /**
@@ -16,6 +16,8 @@ class MQTTClient {
         this.config = config
         /** @type {IntervalJitter} */
         this.heartbeat = new IntervalJitter()
+        /** @type {EditorTunnel} */
+        this.tunnel = null
 
         this.sentInitialCheckin = false
         this.initialCheckinTimeout = null
@@ -31,7 +33,9 @@ class MQTTClient {
         this.commandTopic = `ff/v1/${this.teamId}/d/${this.deviceId}/command`
         this.statusTopic = `ff/v1/${this.teamId}/d/${this.deviceId}/status`
         this.logTopic = `ff/v1/${this.teamId}/d/${this.deviceId}/logs`
+        this.responseTopic = `ff/v1/${this.teamId}/d/${this.deviceId}/response`
 
+        /** @type {mqtt.IClientOptions} */
         this.brokerConfig = {
             clientId: config.brokerUsername,
             username: config.brokerUsername,
@@ -67,7 +71,7 @@ class MQTTClient {
             warn(`MQTT connection error: ${err.toString()}`)
         })
 
-        this.client.on('message', (topic, message) => {
+        this.client.on('message', async (topic, message, packet) => {
             debug(`Command from ${topic}`)
             const payload = message.toString()
             try {
@@ -90,10 +94,30 @@ class MQTTClient {
                     return
                 } else if (command.command === 'startEditor') {
                     info('starting Editor access')
-                    tunnel.newEditorTunnel(this.config).connect()
+                    if (this.tunnel) {
+                        this.tunnel.close()
+                        this.tunnel = null
+                    }
+                    // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
+                    this.tunnel = EditorTunnel.create(this.config, { token: command?.payload?.token })
+                    // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
+                    const result = this.tunnel.connect()
+                    // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
+                    this.sendCommandResponse(command, { connected: result, token: command?.payload?.token })
+                    this.sendStatus()
                     return
                 } else if (command.command === 'stopEditor') {
                     info('stopping Editor access')
+                    if (this.tunnel) {
+                        this.tunnel.close()
+                        this.tunnel = null
+                    }
+                    return
+                } else if (command.command === 'upload') {
+                    info('performing upload')
+                    // upload expects a response. get the data and send it back
+                    const response = await this.getUploadData()
+                    this.sendCommandResponse(command, response)
                     return
                 }
                 warn(`Invalid command type received from platform: ${command.command}`)
@@ -144,6 +168,35 @@ class MQTTClient {
         this.client.publish(this.statusTopic, JSON.stringify(payload))
     }
 
+    sendStatus () {
+        const payload = this.agent.getState()
+        if (!payload) {
+            return
+        }
+        debug('Sending status message')
+        this.client.publish(this.statusTopic, JSON.stringify(payload))
+    }
+
+    async getUploadData (options) {
+        options = options || {}
+        const uploadFlows = typeof options.uploadFlows === 'boolean' ? options.uploadFlows : true // default to true
+        const uploadCredentials = typeof options.uploadCredentials === 'boolean' ? options.uploadCredentials : true // default to true
+        const uploadPackage = typeof options.uploadPackage === 'boolean' ? options.uploadPackage : true // default to true
+        const data = {}
+        data.state = this.agent.getState()
+        if (uploadFlows) {
+            // data.flows = [{ id: 'test', type: 'tab', label: 'Flow 1', disabled: false, info: '' }]
+            data.flows = await this.agent.getCurrentFlows()
+        }
+        if (uploadCredentials) {
+            data.credentials = await this.agent.getCurrentCredentials()
+        }
+        if (uploadPackage) {
+            data.package = await this.agent.getCurrentPackage()
+        }
+        return data
+    }
+
     setProject (project) {
         if (project !== this.activeProject) {
             if (this.activeProject) {
@@ -164,6 +217,35 @@ class MQTTClient {
         if (this.logEnabled) {
             this.client.publish(this.logTopic, JSON.stringify(logMessage))
         }
+    }
+
+    /**
+     * Sends a well formed command/response message in response to a command request
+     * @param {*} request The command to respond to
+     * @param {*} response The payload to send back to the platform
+     */
+    sendCommandResponse (request, response) {
+        const correlationData = request?.correlationData
+        const responseTopic = request?.responseTopic || this.responseTopic
+        const command = request?.command
+
+        if (!correlationData || !responseTopic || !command) {
+            warn('Invalid command response, cannot send response to forge platform')
+            return
+        }
+        const message = {
+            teamId: this.teamId, // for message routing and verification
+            deviceId: this.deviceId, // for message routing and verification
+            command, // for command response verification
+            correlationData, // for correlating response with request
+            payload: response // the actual response payload
+        }
+        const messageJSON = JSON.stringify(message)
+        this.client.publish(responseTopic, messageJSON, (err) => {
+            if (err) {
+                warn(`Error sending response to command ${command}: ${err}`)
+            }
+        })
     }
 }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -1,11 +1,67 @@
 const settings = require('./settings.json')
+const editorTheme = settings.editorTheme || {}
+const themeName = editorTheme.theme || 'forge-light'
+const themeSettings = settings[themeName] || {}
+
+const auth = {
+    type: 'credentials',
+    tokenHeader: 'x-access-token',
+    // tokenHeader: 'authorization',
+    tokens: function (token) {
+        return new Promise(function (resolve, reject) {
+            // check token is valid
+            // TODO: Consider calling the an auth service endpoint to validate the token
+            // against the temp auto generated ffde_ token (`tunnelManager.verifyToken(deviceId, token)`)
+            // as it stands, local access wont work anyway since the token is passed in the header
+            // on ws connect and validated upon tunnelling connection. The worst that can happen is the
+            // link is shared and the tunnel is left open
+            const valid = true
+            if (valid) {
+                // return auth.users('forge')
+                resolve({ username: 'forge', permissions: '*' })
+                return
+            }
+            resolve(null)
+        })
+    },
+    users: function (username) {
+        return new Promise(function (resolve) {
+            if (username === 'forge') {
+                resolve({ username: 'forge', permissions: '*' })
+            } else if (username === 'viewer') {
+                resolve({ username: 'viewer', permissions: 'read' })
+            } else {
+                resolve(null)
+            }
+        })
+    },
+    authenticate: function (username, password) {
+        return new Promise(function (resolve) {
+            const valid = username === 'forge' // && password === 'admin'
+            if (valid) {
+                const user = { username: 'forge', permissions: '*' }
+                resolve(user)
+            } else {
+                // Resolve with null to indicate the username/password pair
+                // were not valid.
+                resolve(null)
+            }
+        })
+    },
+    default: function () {
+        return new Promise(function (resolve) {
+            resolve(null)
+        })
+    }
+}
 
 module.exports = {
     flowFile: 'flows.json',
     uiHost: '0.0.0.0',
     uiPort: settings.port,
-    // httpAdminRoot: false,
-    // disableEditor: true,
+    adminAuth: auth,
+    httpAdminRoot: 'device-editor',
+    disableEditor: false, // permit editing of device flows as of FF v1.7.0
     externalModules: {
         autoInstall: true,
         palette: {
@@ -58,5 +114,7 @@ module.exports = {
                 }
             }
         }
-    }
+    },
+    [themeName]: { ...themeSettings },
+    editorTheme: { ...editorTheme }
 }

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -2,50 +2,47 @@ const settings = require('./settings.json')
 const editorTheme = settings.editorTheme || {}
 const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
+const { default: got } = require('got')
 
 const auth = {
-    type: 'credentials',
-    tokenHeader: 'x-access-token',
-    // tokenHeader: 'authorization',
+    type: 'credentials', // the type of the auth
+    tokenHeader: 'x-access-token', // the header where node-red expects to find the token
     tokens: function (token) {
         return new Promise(function (resolve, reject) {
-            // check token is valid
-            // TODO: Consider calling the an auth service endpoint to validate the token
-            // against the temp auto generated ffde_ token (`tunnelManager.verifyToken(deviceId, token)`)
-            // as it stands, local access wont work anyway since the token is passed in the header
-            // on ws connect and validated upon tunnelling connection. The worst that can happen is the
-            // link is shared and the tunnel is left open
-            const valid = true
-            if (valid) {
-                // return auth.users('forge')
-                resolve({ username: 'forge', permissions: '*' })
+            // call the endpoint to validate the token
+            const [prefix, deviceId] = (token + '').split('_')
+            if (prefix !== 'ffde' || !deviceId || !token) {
+                resolve(null)
                 return
             }
-            resolve(null)
+            got.get(`${settings.flowforge.forgeURL}/api/v1/remote/editor/`, {
+                timeout: 2000,
+                headers: {
+                    'x-device-id': deviceId,
+                    'x-access-token': token,
+                    'user-agent': 'FlowForge Device Agent Node-RED admin auth'
+                }
+            }).then((res) => {
+                const { username, permissions } = JSON.parse(res.body)
+                if (username && permissions) {
+                    resolve({ username, permissions })
+                    return
+                }
+                resolve(null)
+            }).catch((err) => {
+                console.error(err)
+                resolve(null)
+            })
         })
     },
     users: function (username) {
         return new Promise(function (resolve) {
-            if (username === 'forge') {
-                resolve({ username: 'forge', permissions: '*' })
-            } else if (username === 'viewer') {
-                resolve({ username: 'viewer', permissions: 'read' })
-            } else {
-                resolve(null)
-            }
+            resolve(null)
         })
     },
     authenticate: function (username, password) {
         return new Promise(function (resolve) {
-            const valid = username === 'forge' // && password === 'admin'
-            if (valid) {
-                const user = { username: 'forge', permissions: '*' }
-                resolve(user)
-            } else {
-                // Resolve with null to indicate the username/password pair
-                // were not valid.
-                resolve(null)
-            }
+            resolve(null)
         })
     },
     default: function () {

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -4,8 +4,8 @@ module.exports = {
     flowFile: 'flows.json',
     uiHost: '0.0.0.0',
     uiPort: settings.port,
-    httpAdminRoot: false,
-    disableEditor: true,
+    // httpAdminRoot: false,
+    // disableEditor: true,
     externalModules: {
         autoInstall: true,
         palette: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "got": "^11.8.6",
         "mqtt": "^4.3.7",
         "semver": "^7.3.8",
-        "yaml": "^2.1.1"
+        "yaml": "^2.1.1",
+        "websocket": "^1.0.34"
     },
     "devDependencies": {
         "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
         "got": "^11.8.6",
         "mqtt": "^4.3.7",
         "semver": "^7.3.8",
-        "yaml": "^2.1.1",
-        "websocket": "^1.0.34"
+        "ws": "^8.13.0",
+        "yaml": "^2.1.1"
     },
     "devDependencies": {
+        "aedes": "^0.49.0",
+        "aedes-server-factory": "^0.2.1",
         "eslint": "^8.25.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-node": "^11.1.0",

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -1,0 +1,275 @@
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+const path = require('path')
+const fs = require('fs/promises')
+const os = require('os')
+const Aedes = require('aedes')
+
+const { createServer } = require('aedes-server-factory')
+const MQTT = require('mqtt')
+const { MQTTClient: MQTTClientComms } = require('../../../lib/mqtt')
+const EditorTunnel = require('../../../lib/editor/tunnel')
+
+/** creates a mock Agent with sinon fakes for the methods
+ * getState, setState, getCurrentFlows, getCurrentCredentials, getCurrentPackage
+ * @param {object} opts
+ * @param {string} opts.currentMode
+ * @param {string} opts.currentSnapshot
+ * @param {string} opts.currentProject
+ * @param {string} opts.currentSettings
+ * @param {string} opts.state
+ * @param {object} opts.flows
+ * @param {string} opts.credentials
+ * @param {string} opts.package
+ * @returns {Agent}
+ */
+function createAgent (opts) {
+    opts = opts || {}
+    opts.state = opts.state || 'stopped'
+    const newAgent = function () {
+        this.updating = false
+        this.currentMode = opts.currentMode
+        this.currentSnapshot = opts.currentSnapshot
+        this.currentProject = opts.currentProject
+        this.currentSettings = opts.currentSettings
+        this.state = opts.currentState
+        this.flows = opts.flows
+        this.credentials = opts.credentials
+        this.package = opts.package
+        const agent = this
+        return {
+            currentMode: agent.currentMode,
+            currentSnapshot: agent.currentSnapshot,
+            currentProject: agent.currentProject,
+            currentSettings: agent.currentSettings,
+            getState: sinon.fake.returns(agent.state),
+            setState: sinon.fake.call(function (state) {
+                agent.state = state
+            }),
+            getCurrentFlows: sinon.fake.returns(agent.flows),
+            getCurrentCredentials: sinon.fake.returns(agent.credentials),
+            getCurrentPackage: sinon.fake.returns(agent.package)
+        }
+    }
+    return newAgent()
+}
+
+describe('MQTT Comms', function () {
+    // common variables
+    /** @type {string} agent config dir */ let configDir
+    /** @type {import('aedes-server-factory').Server} MQTT WS */ let httpServer
+    /** @type {Aedes} MQTT Broker */ let aedes = null
+    /** @type {MQTT.MqttClient} MQTT Client */ let mqtt
+    /** @type {MQTTClientComms} Agent mqttClient comms */ let mqttClient = null
+    let currentId = 0 // incrementing id for each agent
+    const sockets = {} // Maintain a hash of all connected sockets (for closing them later)
+
+    function createMQTTClient (opts) {
+        opts = opts || {}
+        currentId++
+        const team = opts.team || `team${currentId}`
+        const device = opts.device || `device${currentId}`
+        const project = opts.project !== null ? `project${currentId}` : null
+        const snapshot = opts.snapshotId !== null ? { id: opts.snapshotId } : null
+        const settings = opts.settingsId !== null ? { hash: opts.settingsId } : null
+        const mode = opts.mode || 'developer'
+
+        const agent = createAgent({
+            currentMode: mode,
+            currentProject: project,
+            currentSettings: settings,
+            currentSnapshot: snapshot,
+            state: opts.state || 'stopped',
+            flows: opts.flows,
+            credentials: opts.credentials,
+            package: opts.package
+        })
+
+        return new MQTTClientComms(agent, {
+            dir: configDir,
+            forgeURL: 'http://localhost:9000',
+            brokerURL: 'ws://localhost:9001',
+            brokerUsername: `device:${team}:${device}`,
+            brokerPassword: 'pass'
+        })
+    }
+
+    before(async function () {
+        aedes = new Aedes()
+        const port = 9001
+        httpServer = createServer(aedes, { ws: true })
+        httpServer.listen(port, function () {
+            console.log('websocket server listening on port ', port)
+        })
+        let nextSocketId = 0
+        httpServer.on('connection', function (socket) {
+        // Add a newly connected socket
+            const socketId = nextSocketId++
+            sockets[socketId] = socket
+            console.log('socket', socketId, 'opened')
+
+            // Remove the socket when it closes
+            socket.on('close', function () {
+                console.log('socket', socketId, 'closed')
+                delete sockets[socketId]
+            })
+        })
+
+        mqtt = MQTT.connect(`ws://localhost:${port}`)
+
+        try {
+            sinon.stub(EditorTunnel, 'create').callsFake(function () {
+                return {
+                    connect: sinon.stub().returns(true),
+                    close: sinon.stub(),
+                    dummy: sinon.stub().returns('for ensuring the sandbox is used once')
+                }
+            })
+        } catch (error) {
+            console.log(error)
+        }
+        EditorTunnel.create().dummy() // ensure the sandbox is used once
+    })
+    after(async function () {
+        mqtt && mqtt.end()
+        aedes.close()
+        aedes.removeAllListeners()
+        if (httpServer) {
+            // Close the server
+            httpServer.close(function () { console.log('Server closed!') })
+            // Destroy all open sockets
+            for (const socketId in sockets) {
+                console.log('socket', socketId, 'destroyed')
+                sockets[socketId].destroy()
+            }
+        }
+        sinon.restore()
+    })
+
+    beforeEach(async function () {
+        configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-launcher-'))
+        await fs.mkdir(path.join(configDir, 'project'))
+        mqttClient = createMQTTClient()
+    })
+
+    afterEach(async function () {
+        await fs.rm(configDir, { recursive: true, force: true })
+        mqttClient.stop()
+        mqttClient = null
+    })
+
+    async function mqttPubAndAwait (topic, payload, responseTopic) {
+        return new Promise((resolve, reject) => {
+            // if timeout, reject
+            const timeOver = setTimeout(() => {
+                cleanUp()
+                reject(new Error('mqttPubAndAwait timed out'))
+            }, 500)
+            const onMessage = (topic, message) => {
+                const m = JSON.parse(message.toString())
+                console.log('mqtt.on(message => received message %s %s', topic, m)
+                cleanUp(timeOver)
+                resolve(m)
+            }
+            const cleanUp = () => {
+                mqtt.unsubscribe(responseTopic)
+                mqtt.off('message', onMessage)
+                clearTimeout(timeOver)
+            }
+            // if message received, resolve
+            mqtt.subscribe(responseTopic)
+            mqtt.on('message', onMessage)
+            // publish message
+            mqtt.publish(topic, payload, function (err) {
+                if (err) {
+                    cleanUp()
+                    reject(err)
+                }
+            })
+        })
+    }
+
+    it('Creates the MQTT Comms Client', async function () {
+        mqttClient.should.have.a.property('agent').and.be.an.Object()
+        mqttClient.should.have.a.property('config').and.be.an.Object()
+        mqttClient.config.should.have.a.property('dir').and.be.a.String()
+        mqttClient.config.should.have.a.property('forgeURL').and.be.a.String()
+        mqttClient.config.should.have.a.property('brokerURL').and.be.a.String()
+        mqttClient.config.should.have.a.property('brokerUsername').and.be.a.String()
+        mqttClient.config.should.have.a.property('brokerPassword').and.be.a.String()
+        mqttClient.should.have.a.property('heartbeat').and.be.an.Object()
+        mqttClient.should.have.a.property('tunnel').and.be.null()
+        mqttClient.should.have.a.property('sentInitialCheckin').and.be.false()
+        mqttClient.should.have.a.property('initialCheckinTimeout').and.be.null()
+        mqttClient.should.have.a.property('activeProject').and.be.null()
+        mqttClient.should.have.a.property('statusTopic').and.be.a.String()
+        mqttClient.should.have.a.property('logTopic').and.be.a.String()
+        mqttClient.should.have.a.property('commandTopic').and.be.a.String()
+        mqttClient.should.have.a.property('responseTopic').and.be.a.String()
+        mqttClient.should.have.a.property('brokerConfig').and.be.an.Object()
+        mqttClient.brokerConfig.should.have.a.property('clientId').and.be.a.String()
+        mqttClient.brokerConfig.should.have.a.property('username').and.be.a.String()
+        mqttClient.brokerConfig.should.have.a.property('password').and.be.a.String()
+    })
+    it('MQTT Client topics are set', async function () {
+        const statusTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/status`
+        const logTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/logs`
+        const commandTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/command`
+        const responseTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/response`
+        mqttClient.should.have.a.property('agent').and.be.an.Object()
+        // mqttClient.should.have.a.property('client').and.be.an.Object()
+        mqttClient.should.have.a.property('statusTopic').and.be.a.String().and.equal(statusTopic)
+        mqttClient.should.have.a.property('logTopic').and.be.a.String().and.equal(logTopic)
+        mqttClient.should.have.a.property('commandTopic').and.be.a.String().and.equal(commandTopic)
+        mqttClient.should.have.a.property('responseTopic').and.be.a.String().and.equal(responseTopic)
+    })
+    it('MQTT Comms Client initialises an MQTT Client', async function () {
+        mqttClient.start()
+        mqttClient.should.have.a.property('client').and.be.an.Object()
+        mqttClient.stop()
+    })
+    it('MQTT command startEditor gets a response', async function () {
+        mqttClient.start()
+
+        const commandTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/command`
+        const responseTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/response`
+        console.log('commandTopic', commandTopic)
+        console.log('responseTopic', responseTopic)
+        mqttClient.should.have.a.property('client').and.be.an.Object()
+        mqttClient.should.have.a.property('commandTopic').and.be.a.String().and.equal(commandTopic)
+        mqttClient.should.have.a.property('responseTopic').and.be.a.String().and.equal(responseTopic)
+
+        const payload = {
+            command: 'startEditor',
+            correlationData: 'correlationData-test',
+            responseTopic,
+            payload: {
+                token: 'token-test'
+            }
+        }
+        const payloadStr = JSON.stringify(payload)
+
+        // short delay to allow mqtt to connect and stack to unwind
+        await new Promise(resolve => setTimeout(resolve, 500))
+        const response = await mqttPubAndAwait(commandTopic, payloadStr, responseTopic)
+        response.should.have.a.property('command', 'startEditor')
+        response.should.have.a.property('correlationData', 'correlationData-test')
+        response.should.have.a.property('payload').and.be.an.Object()
+        response.payload.should.have.a.property('connected', true)
+        response.payload.should.have.a.property('token', 'token-test')
+        await new Promise(resolve => setTimeout(resolve, 50))
+        console.log('done')
+    })
+    it.skip('MQTT command stopEditor stops the editor', async function () {
+        // TODO
+    })
+    it.skip('MQTT command startLog starts logs', async function () {
+        // TODO
+    })
+    it.skip('MQTT command stopLog stops logs', async function () {
+        // TODO
+    })
+    it.skip('MQTT command upload gets a response with a snapshot', async function () {
+        // TODO
+    })
+})


### PR DESCRIPTION
## Description

Support remote device access, editing and snapshotting with NR token Auth to prevent local access

### Notes for debugging and comprehension

1. The auth method is essentially as described in the issue mermaid diagram except for the route names as described by Bens comment in the following comment n the issue
2. Search the code for "Enable Device Editor" to see the 12 steps of acheiving a successful tunnel 
   1. ![image](https://user-images.githubusercontent.com/44235289/234251743-22c00818-5f98-4941-824d-893e54717f01.png)
   2. 
## Related PRs
https://github.com/flowforge/flowforge/pull/2042

## Related Issue(s)
https://github.com/flowforge/flowforge/issues/1821



## TODO
- [ ] FF theme (since no longer a separate package, we may need to be creative or have a dist version embedded) 
- [x] tests

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

