### PR TITLE
Update remote access urls and websocket message queueing

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -60,30 +60,31 @@ class EditorTunnel {
             this.close()
         }
 
-        const socket = newWsConnection(`${this.url}api/v1/remote/editor/inboundWS/${this.deviceId}/${this.options.token}`, {
+        const socket = newWsConnection(`${this.url}api/v1/devices/${this.deviceId}/editor/comms/${this.options.token}`, {
             headers: {
                 'x-access-token': this.options.token
             }
         })
         socket.onopen = (evt) => {
-            console.log('socket.onopen')
             socket.on('message', async (message) => {
                 // a message from the editor
                 const request = JSON.parse(message.toString('utf-8'))
                 if (request.ws) {
-                    if (request.id && thisTunnel.wsClients[request.id] && thisTunnel.wsClients[request.id].readyState !== WebSocket.OPEN) {
-                        thisTunnel.wsClients[request.id].close()
-                        thisTunnel.wsClients[request.id] = null
-                        // short delay to allow the socket to close and stack to unwind
-                        await new Promise((resolve) => setTimeout(resolve, 1))
-                    }
-                    if (request.id && thisTunnel.wsClients[request.id] && thisTunnel.wsClients[request.id]?.readyState === WebSocket.OPEN) {
-                        thisTunnel.wsClients[request.id].send(request.body)
-                    } else {
+                    // This is a websocket packet to proxy.
+                    if (request.id && request.url) {
+                        // This is the initial connect request.
                         const tunnelledWSClient = newWsConnection(`ws://localhost:${thisTunnel.port}/device-editor${request.url}`)
+                        thisTunnel.wsClients[request.id] = tunnelledWSClient
+                        tunnelledWSClient._messageQueue = []
+                        tunnelledWSClient.sendOrQueue = function (payload) {
+                            if (this.readyState !== WebSocket.OPEN) {
+                                this._messageQueue.push(payload)
+                            } else {
+                                this.send(payload)
+                            }
+                        }
                         tunnelledWSClient._id = request.id // for debugging and tracking
                         tunnelledWSClient.on('open', () => {
-                            console.log('tunnelledWSClient.onopen')
                             tunnelledWSClient.on('message', (data) => {
                                 const sendData = {
                                     id: request.id,
@@ -92,7 +93,9 @@ class EditorTunnel {
                                 }
                                 socket.send(JSON.stringify(sendData))
                             })
-                            thisTunnel.wsClients[request.id] = tunnelledWSClient
+                            while (tunnelledWSClient._messageQueue.length > 0) {
+                                tunnelledWSClient.send(tunnelledWSClient._messageQueue.shift())
+                            }
                             // tunnelledWSClient.send(JSON.stringify(request)) // TODO: send the request body sent initially?
                         })
                         tunnelledWSClient.on('close', (code, reason) => {
@@ -105,7 +108,10 @@ class EditorTunnel {
                             thisTunnel.wsClients[request.id]?.close(1006, err.message)
                             thisTunnel.wsClients[request.id] = null
                         })
-                        // await isWsConnectionReady(tunnelledWSClient) // unreliable
+                    } else if (thisTunnel.wsClients[request.id]) {
+                        thisTunnel.wsClients[request.id].sendOrQueue(request.body)
+                    } else {
+                        this.close(1006, 'Non-connect packet received for unknown connection id') // 1006 = Abnormal closure
                     }
                 } else {
                     const reqHeaders = { ...request.headers }

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -93,30 +93,28 @@ class MQTTClient {
                     this.logEnabled = false
                     return
                 } else if (msg.command === 'startEditor') {
-                    info('starting Editor access')
+                    info('Enabling remote editor access')
                     if (this.tunnel) {
                         this.tunnel.close()
                         this.tunnel = null
                     }
                     // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
-                    console.log('creating tunnel', this.config, msg)
                     this.tunnel = EditorTunnel.create(this.config, { token: msg?.payload?.token })
                     // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
                     const result = await this.tunnel.connect()
                     // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
-                    console.log('sending response', { connected: result, token: msg?.payload?.token })
                     this.sendCommandResponse(msg, { connected: result, token: msg?.payload?.token })
                     this.sendStatus()
                     return
                 } else if (msg.command === 'stopEditor') {
-                    info('stopping Editor access')
+                    info('Disabling remote editor access')
                     if (this.tunnel) {
                         this.tunnel.close()
                         this.tunnel = null
                     }
                     return
                 } else if (msg.command === 'upload') {
-                    info('performing upload')
+                    info('Capturing device snapshot')
                     // upload expects a response. get the data and send it back
                     const response = await this.getUploadData()
                     this.sendCommandResponse(msg, response)

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -15,10 +15,9 @@ const auth = {
                 resolve(null)
                 return
             }
-            got.get(`${settings.flowforge.forgeURL}/api/v1/remote/editor/`, {
+            got.get(`${settings.flowforge.forgeURL}/api/v1/devices/${deviceId}/editor/token`, {
                 timeout: 2000,
                 headers: {
-                    'x-device-id': deviceId,
                     'x-access-token': token,
                     'user-agent': 'FlowForge Device Agent Node-RED admin auth'
                 }


### PR DESCRIPTION
## Description

 - Updates the URLs used to access the forge APIs (corresponding PR against ff/ff to follow).
 - Tidies up logging messages
 - Fixes websocket proxying to ensure messages are queued if still waiting for onward ws to come ready
