### PR TITLE
Increase the timeout to create WS connection to Forge

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -17,7 +17,7 @@ async function isWsConnectionReady (ws) {
             } else {
                 reject(new Error('Connection timeout'))
             }
-        }, 200)
+        }, 1000)
     })
     return connection
 }

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -17,7 +17,7 @@ async function isWsConnectionReady (ws) {
             } else {
                 reject(new Error('Connection timeout'))
             }
-        }, 1000)
+        }, 2000)
     })
     return connection
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Original 200ms timeout was too quick, set to 1s to start with.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

