### PR TITLE
Add verbose logging of proxy requests and shift to 127.0.0.1

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,3 +1,4 @@
+const { info, warn, debug } = require('../logging/log')
 const WebSocket = require('ws')
 const got = require('got')
 
@@ -59,8 +60,10 @@ class EditorTunnel {
         if (this.socket) {
             this.close()
         }
+        const forgeWSEndpoint = `${this.url}api/v1/devices/${this.deviceId}/editor/comms/${this.options.token}`
+        info(`Connecting editor tunner to ${forgeWSEndpoint}`)
         // * Enable Device Editor (Step 8) - (device->forge:WS) Initiate WS connection (with token)
-        const socket = newWsConnection(`${this.url}api/v1/devices/${this.deviceId}/editor/comms/${this.options.token}`, {
+        const socket = newWsConnection(forgeWSEndpoint, {
             headers: {
                 'x-access-token': this.options.token
             }
@@ -73,7 +76,10 @@ class EditorTunnel {
                     // This is a websocket packet to proxy.
                     if (request.id && request.url) {
                         // This is the initial connect request.
-                        const tunnelledWSClient = newWsConnection(`ws://localhost:${thisTunnel.port}/device-editor${request.url}`)
+                        const localWSEndpoint = `ws://127.0.0.1:${thisTunnel.port}/device-editor${request.url}`
+                        debug(`Connecting local comms to ${localWSEndpoint}`)
+
+                        const tunnelledWSClient = newWsConnection(localWSEndpoint)
                         thisTunnel.wsClients[request.id] = tunnelledWSClient
                         tunnelledWSClient._messageQueue = []
                         tunnelledWSClient.sendOrQueue = function (payload) {
@@ -99,7 +105,6 @@ class EditorTunnel {
                             // tunnelledWSClient.send(JSON.stringify(request)) // TODO: send the request body sent initially?
                         })
                         tunnelledWSClient.on('close', (code, reason) => {
-                            console.warn('tunnelledWSClient.onclose', code)
                             thisTunnel.wsClients[request.id]?.removeAllListeners()
                             thisTunnel.wsClients[request.id] = null
                         })
@@ -122,15 +127,17 @@ class EditorTunnel {
                     // make request to the local device
                     // add leading slash (if missing)
                     const url = request.url.startsWith('/') ? request.url : `/${request.url || ''}`
-                    const fullUrl = `http://localhost:${thisTunnel.port}/device-editor${url}`
+                    const fullUrl = `http://127.0.0.1:${thisTunnel.port}/device-editor${url}`
                     // ↓ useful for debugging but very noisy
                     // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
+                    debug(`proxy [${request.method}] ${fullUrl}`)
                     got(fullUrl, {
                         headers: reqHeaders,
                         method: request.method,
                         body: request.body,
                         throwErrors: false
                     }).then(response => {
+                        debug(`proxy [${request.method}] ${fullUrl} : sending response`)
                         // send response back to the forge
                         socket.send(JSON.stringify({
                             id: request.id,
@@ -139,6 +146,7 @@ class EditorTunnel {
                             status: response.statusCode
                         }))
                     }).catch(_err => {
+                        debug(`proxy [${request.method}] ${fullUrl} : error ${_err.toString()}`)
                         // ↓ useful for debugging but noisy due to .map files
                         // console.log(err)
                         // console.log(JSON.stringify(request))
@@ -152,10 +160,11 @@ class EditorTunnel {
             })
         }
         socket.on('close', (code, reason) => {
-            console.warn('socket.close', code, reason)
+            info(`Editor tunnel closed code=${code} reason=${reason}`)
             this.close(code, reason)
         })
         socket.on('error', (err) => {
+            warn(`Editor tunnel error: ${err}`)
             console.warn('socket.error', err)
             this.close(1006, err.message) // 1006 = Abnormal Closure
         })
@@ -182,6 +191,7 @@ class EditorTunnel {
         if (this.socket) {
             this.socket.close()
             this.socket.removeAllListeners()
+            info('Editor tunnel closed')
         }
         this.socket = null
     }


### PR DESCRIPTION
## Description

Improves logging of the device agent around the editor tunnel.

The are also verbose-only logging of individual proxied requests so we can trace traffic.

Also modifies local urls to be 127.0.0.1 to avoid ipv6 issues on node 18+