### PR TITLE
Set editor header.title to device name if not otherwise set

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -4,6 +4,9 @@ const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
 const { default: got } = require('got')
 
+settings.editorTheme.header = settings.editorTheme.header || {}
+settings.editorTheme.header.title = settings.editorTheme.header.title || `Device: ${process.env.FF_DEVICE_NAME}`
+
 const auth = {
     type: 'credentials', // the type of the auth
     tokenHeader: 'x-access-token', // the header where node-red expects to find the token


### PR DESCRIPTION
## Description

When accessing the editor remotely, the title said 'node-red' and there was no indication what device was being edited.

This PR sets the header title to `Device: <device-name>` if it isn't otherwise set.