### PR TITLE
Warn if NR is not running when trying to start editor

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,4 +1,3 @@
-
 let verbose = false
 function log (msg, level) {
     console.log(`[AGENT] ${new Date().toLocaleString([], { dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -99,6 +99,11 @@ class MQTTClient {
                         this.tunnel.close()
                         this.tunnel = null
                     }
+                    if (!this.agent.launcher) {
+                        info('No running Node-RED instance, not starting editor')
+                        this.sendCommandResponse(msg, { connected: false, token: msg?.payload?.token, error: 'noNRRunning' })
+                        return
+                    }
                     // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
                     this.tunnel = EditorTunnel.create(this.config, { token: msg?.payload?.token })
                     // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -255,7 +255,7 @@ describe('MQTT Comms', function () {
         response.should.have.a.property('command', 'startEditor')
         response.should.have.a.property('correlationData', 'correlationData-test')
         response.should.have.a.property('payload').and.be.an.Object()
-        response.payload.should.have.a.property('connected', true)
+        response.payload.should.have.a.property('connected', false)
         response.payload.should.have.a.property('token', 'token-test')
         await new Promise(resolve => setTimeout(resolve, 50))
         console.log('done')


### PR DESCRIPTION
part of flowforge/flowforge#2233

## Description

<!-- Describe your changes in detail -->
Should raise an error (and log) if Node-RED is not running when trying to start the device editor access tunnel.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowforge/flowforge#2233


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

