### PR TITLE
Pull latest snapshot in dev mode if started without any project config

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -208,7 +208,11 @@ class Agent {
             // Check if any updates are needed
             let updateSnapshot = false
             let updateSettings = false
-            if (inhibitUpdates === false) {
+            if (this.currentState === 'unknown' && inhibitUpdates && !this.currentSnapshot && !this.currentProject && newState.project) {
+                info('Developer Mode: no flows found - updating to latest snapshot')
+                updateSnapshot = true
+                updateSettings = true
+            } else if (inhibitUpdates === false) {
                 if (Object.hasOwn(newState, 'project') && (!this.currentSnapshot || newState.project !== this.currentProject)) {
                     info('New instance assigned')
                     this.currentProject = newState.project

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -77,10 +77,14 @@ class MQTTClient {
             try {
                 const msg = JSON.parse(_message)
                 if (msg.command === 'update') {
+                    if (!this.sentInitialCheckin) {
+                        // We haven't sent the initial checkin, but we've received
+                        // an update; no need to resend the checkin
+                        this.sentInitialCheckin = true
+                    }
                     if (this.initialCheckinTimeout) {
                         clearTimeout(this.initialCheckinTimeout)
                         this.initialCheckinTimeout = null
-                        this.sentInitialCheckin = true
                     }
                     this.agent.setState(msg)
                     return

--- a/test/unit/lib/agent_spec.js
+++ b/test/unit/lib/agent_spec.js
@@ -573,6 +573,31 @@ describe('Agent', function () {
             agent.httpClient.getSettings.called.should.be.false()
             agent.httpClient.getSnapshot.called.should.be.false()
         })
+
+        it('Updates when in developer mode but no local project defined', async function () {
+            const agent = createHTTPAgent()
+            agent.currentProject = null
+            agent.currentSnapshot = null
+            agent.currentSettings = null
+
+            const testLauncher = launcher.newLauncher()
+            agent.launcher = testLauncher
+            agent.httpClient.getSettings.resolves({ hash: 'newSettingsId' })
+            agent.httpClient.getSnapshot.resolves({ id: 'newSnapshotId' })
+
+            await agent.setState({
+                project: 'newProject',
+                settings: 'newSettingsId',
+                snapshot: 'newSnapshotId',
+                mode: 'developer'
+
+            })
+            testLauncher.stop.called.should.be.true()
+            should.exist(agent.launcher)
+            agent.launcher.should.not.eql(testLauncher)
+            agent.launcher.writeConfiguration.called.should.be.true()
+            agent.launcher.start.called.should.be.true()
+        })
     })
 
     describe('provisioning', function () {


### PR DESCRIPTION
Fixes #97

If we find ourselves without a project set *and* in developer mode, this will apply the latest snapshot to ensure Node-RED is running so we can enable editor access.

Also noticed we were logging a timeout on the initial checking message (mqtt only) - if the update command arrives before we send the checkin. Tweaked the logic so we don't resend the initial checkin if we've already heard from the platform.