### PR TITLE
Support https configuration from device.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ Extra options   | Description
 `intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
 `port`          | The port to listen on. Default: 1880
 `moduleCache`   | If the device can not access npmjs.org then use the node modules cache in `module_cache` directory. Default `false`
+`https`         | Enable HTTPS. See below for details
+
+
+#### `https` configuration
+
+The `https` configuration option can be used to enable HTTPS within Node-RED. The values
+are passed through to the [Node-RED `https` setting](https://nodered.org/docs/user-guide/runtime/configuration).
+
+The `ca`, `key` and `cert` properties can be used to provide custom certificates and keys.
+The values should be set to the contents of the certificate/key.
+
+Alternatively, the properties `caPath`, `keyPath` and `certPath` can be used instead
+to provide absolute paths to files containing the certificates/keys.
+
+```yml
+https:
+   keyPath: /opt/flowforge-device/certs/key.pem
+   certPath: /opt/flowforge-device/certs/cert.pem
+   caPath: /opt/flowforge-device/certs/ca.pem
+```
+
 
 
 ### `device.yml` - for provisioning

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -40,6 +40,9 @@ class EditorTunnel {
         const forgeURL = new URL(config.forgeURL)
         forgeURL.protocol = forgeURL.protocol === 'http:' ? 'ws:' : 'wss:'
         this.url = forgeURL.toString()
+
+        this.localProtocol = config.https ? 'https' : 'http'
+        this.localWSProtocol = config.https ? 'wss' : 'ws'
     }
 
     /**
@@ -76,10 +79,10 @@ class EditorTunnel {
                     // This is a websocket packet to proxy.
                     if (request.id && request.url) {
                         // This is the initial connect request.
-                        const localWSEndpoint = `ws://127.0.0.1:${thisTunnel.port}/device-editor${request.url}`
+                        const localWSEndpoint = `${thisTunnel.localWSProtocol}://127.0.0.1:${thisTunnel.port}/device-editor${request.url}`
                         debug(`Connecting local comms to ${localWSEndpoint}`)
 
-                        const tunnelledWSClient = newWsConnection(localWSEndpoint)
+                        const tunnelledWSClient = newWsConnection(localWSEndpoint, { rejectUnauthorized: false })
                         thisTunnel.wsClients[request.id] = tunnelledWSClient
                         tunnelledWSClient._messageQueue = []
                         tunnelledWSClient.sendOrQueue = function (payload) {
@@ -127,7 +130,7 @@ class EditorTunnel {
                     // make request to the local device
                     // add leading slash (if missing)
                     const url = request.url.startsWith('/') ? request.url : `/${request.url || ''}`
-                    const fullUrl = `http://127.0.0.1:${thisTunnel.port}/device-editor${url}`
+                    const fullUrl = `${thisTunnel.localProtocol}://127.0.0.1:${thisTunnel.port}/device-editor${url}`
                     // ↓ useful for debugging but very noisy
                     // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
                     debug(`proxy [${request.method}] ${fullUrl}`)
@@ -135,7 +138,8 @@ class EditorTunnel {
                         headers: reqHeaders,
                         method: request.method,
                         body: request.body,
-                        throwErrors: false
+                        throwErrors: false,
+                        rejectUnauthorized: false
                     }).then(response => {
                         debug(`proxy [${request.method}] ${fullUrl} : sending response`)
                         // send response back to the forge

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -171,6 +171,29 @@ class Launcher {
                 projectLink
             }
         }
+        if (this.config.https) {
+            // The `https` config can contain any valid setting from the Node-RED
+            // https object. For convenience, the `key`, `ca` and `cert` settings
+            // have `*Path` equivalents that can be used to provide a path to load
+            // the corresponding values from. The loading of the file contents
+            // is done in settings.js - but we validate the files exist here to
+            // ensure the config looks valid.
+            const httpsErrors = []
+            ;['keyPath', 'caPath', 'certPath'].forEach(key => {
+                if (this.config.https[key]) {
+                    if (!existsSync(this.config.https[key])) {
+                        httpsErrors.push(`https.${key} file not found: ${this.config.https[key]}`)
+                    }
+                }
+            })
+            if (httpsErrors.length > 0) {
+                warn('Invalid HTTPS configuration:')
+                httpsErrors.forEach(err => warn(` - ${err}`))
+                delete this.config.https
+            } else {
+                settings.https = this.config.https
+            }
+        }
         await fs.writeFile(this.files.userSettings, JSON.stringify(settings))
     }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -3,6 +3,7 @@ const editorTheme = settings.editorTheme || {}
 const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
 const { default: got } = require('got')
+const { existsSync, readFileSync } = require('fs')
 
 settings.editorTheme.header = settings.editorTheme.header || {}
 settings.editorTheme.header.title = settings.editorTheme.header.title || `Device: ${process.env.FF_DEVICE_NAME}`
@@ -54,7 +55,7 @@ const auth = {
     }
 }
 
-module.exports = {
+const runtimeSettings = {
     flowFile: 'flows.json',
     uiHost: '0.0.0.0',
     uiPort: settings.port,
@@ -117,3 +118,14 @@ module.exports = {
     [themeName]: { ...themeSettings },
     editorTheme: { ...editorTheme }
 }
+
+if (settings.https) {
+    ;['key', 'ca', 'cert'].forEach(key => {
+        const filePath = settings.https[`${key}Path`]
+        if (filePath && existsSync(filePath)) {
+            settings.https[key] = readFileSync(filePath)
+        }
+    })
+    runtimeSettings.https = settings.https
+}
+module.exports = runtimeSettings

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -78,4 +78,19 @@ describe('Launcher', function () {
         pkg.name.should.eqls('TEST_PROJECT')
         pkg.version.should.eqls('0.0.0-aaaabbbbcccc')
     })
+
+    it('Write Settings - with HTTPS, raw values', async function () {
+        const launcher = newLauncher({
+            ...config,
+            https: {
+                cert: '123',
+                ca: '456',
+                key: '789'
+            }
+        }, 'PROJECTID', setup.snapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('https')
+    })
 })


### PR DESCRIPTION
Part of #110 

Fixes https://github.com/flowforge/flowforge/issues/2257

## Description

This adds support for specifying `https` configuration via `device.yml`.

The properties are passed straight through to Node-RED's `settings.js` file.

In addition, the properties `caPath`, `keyPath`, `certPath` are supported to provide absolute paths to the certs/keys files - removing the need to inline the certs etc in `device.yml`.

ToDo:

 - [ ] Doc updates in `flowforge/flowforge` repo to match

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

