### PR TITLE
Support httpStatic via device.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,20 @@ Extra options   | Description
 ----------------|---------------
 `interval`      | How often, in seconds, the agent checks in with the platform. Default: 60s
 `intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
-`port`          | The port to listen on. Default: 1880
 `moduleCache`   | If the device can not access npmjs.org then use the node modules cache in `module_cache` directory. Default `false`
+
+
+#### Node-RED options
+
+The following options are passed through to Node-RED:
+
+Node-RED options | Description
+----------------|---------------
+`port`          | The port to listen on. Default: 1880
 `https`         | Enable HTTPS. See below for details
+`httpStatic`    | Enable serving of static content from a local path
 
-
-#### `https` configuration
+##### `https` configuration
 
 The `https` configuration option can be used to enable HTTPS within Node-RED. The values
 are passed through to the [Node-RED `https` setting](https://nodered.org/docs/user-guide/runtime/configuration).
@@ -103,7 +111,26 @@ https:
    caPath: /opt/flowforge-device/certs/ca.pem
 ```
 
+##### `httpStatic` configuration
 
+This option can be used to serve content from a local directory.
+
+If set to a path, the files in that directory will be served relative to `/`.
+
+```yml
+httpStatic: /opt/flowforge-device/static-content
+```
+
+It is also possible to configure it with a list of directories and the corresponding
+path they should be served from.
+
+```yml
+httpStatic:
+  - path: /opt/flowforge-device/static-content/images
+    root: /images
+  - path: /opt/flowforge-device/static-content/js
+    root: /js
+```
 
 ### `device.yml` - for provisioning
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -194,6 +194,11 @@ class Launcher {
                 settings.https = this.config.https
             }
         }
+
+        if (this.config.httpStatic) {
+            // The `httpStatic` config is passed straight through to Node-RED
+            settings.httpStatic = this.config.httpStatic
+        }
         await fs.writeFile(this.files.userSettings, JSON.stringify(settings))
     }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -128,4 +128,8 @@ if (settings.https) {
     })
     runtimeSettings.https = settings.https
 }
+
+if (settings.httpStatic) {
+    runtimeSettings.httpStatic = settings.httpStatic
+}
 module.exports = runtimeSettings

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -93,4 +93,14 @@ describe('Launcher', function () {
         const settings = JSON.parse(setFile)
         settings.should.have.property('https')
     })
+    it('Write Settings - with httpStatic', async function () {
+        const launcher = newLauncher({
+            ...config,
+            httpStatic: 'static-path'
+        }, 'PROJECTID', setup.snapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('httpStatic', 'static-path')
+    })
 })


### PR DESCRIPTION
Part of #110 

See also #111 

## Description

Adds support for setting `httpStatic` via the `device.yml` file. The setting is passed straight through to Node-RED's settings file.

