### PR TITLE
doc fix: s/yaml/yml/

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install -g @flowforge/flowforge-device-agent
 ```
 
 Or you can chose to run the Docker container. When you do, you'll need to mount
-the `device.yaml` obtained when [Registering the device](#register-the-device):
+the `device.yml` obtained when [Registering the device](#register-the-device):
 
 ```bash
 docker run --mount /path/to/device.yml:/opt/flowforge/device.yml -p 1880:1880 flowforge/device-agent:latest


### PR DESCRIPTION
As the agent will look for `device.yml`, not the `.yaml`. This change make more copy+paste proof.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

