### PR TITLE
Ensure buffered agent messages have the properly formatted ts prop

### DIFF
--- a/lib/logging/log.js
+++ b/lib/logging/log.js
@@ -6,12 +6,13 @@ let verbose = false
 
 function log (msg, level) {
     console.log(`[AGENT] ${new Date().toLocaleString([], { dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)
+    const jsMsg = { level, msg }
     if (buffer) {
-        buffer.add({ level, msg })
+        buffer.add(jsMsg)
     }
     if (mqtt) {
         // publish log message
-        mqtt.log({ level, msg, ts: Date.now() })
+        mqtt.log(jsMsg)
     }
 }
 

--- a/lib/logging/log.js
+++ b/lib/logging/log.js
@@ -48,7 +48,7 @@ function setMQTT (mqttAgent) {
 module.exports = {
     initLogger: configuration => {
         verbose = configuration.verbose
-        buffer = new LogBuffer(configuration.bufferSize | 1000)
+        buffer = new LogBuffer(configuration.bufferSize || 1000)
     },
     info: msg => log(msg, 'info'),
     warn: msg => log(msg, 'warn'),

--- a/test/unit/lib/logging/log_spec.js
+++ b/test/unit/lib/logging/log_spec.js
@@ -1,0 +1,65 @@
+const sleep = require('util').promisify(setTimeout)
+
+const should = require('should') // eslint-disable-line
+const Log = require('../../../../lib/logging/log')
+
+describe('Log', function () {
+    describe('Buffered messages', function () {
+        const mqttMessages = []
+        const mockMqttAgent = {
+            log: (msg) => {
+                mqttMessages.push(msg)
+            }
+        }
+        before(() => {
+            Log.initLogger({ bufferSize: 5 })
+            Log.setMQTT(mockMqttAgent)
+        })
+
+        it('stores correct number of previous log messages', async function () {
+            // Send 6 logs - mix of agent and nr
+            Log.info('m1')
+            Log.info('m2')
+            Log.info('m3')
+            Log.info('m4')
+            await sleep(10)
+            Log.NRlog(JSON.stringify({
+                level: 'info',
+                ts: Date.now(),
+                msg: 'm5'
+            }))
+            Log.info('m6')
+            Log.NRlog(JSON.stringify({
+                level: 'info',
+                ts: Date.now(),
+                msg: 'm7'
+            }))
+
+            const bufferedMessages = Log.getBufferedMessages()
+            // Verify we buffered the last 5
+            bufferedMessages.should.have.length(5)
+            bufferedMessages[0].should.have.property('msg', 'm3')
+            bufferedMessages[4].should.have.property('msg', 'm7')
+            const parseTS = (ts) => {
+                // 16881274135850002
+                (typeof ts).should.equal('string')
+                ts.should.have.length(17)
+                const time = parseInt(ts.substring(0, 13))
+                const index = parseInt(ts.substring(13))
+                return { time, index }
+            }
+
+            // Verify all of the ts properties increment as expected
+            let currentTs = parseTS(bufferedMessages[0].ts)
+            for (let i = 1; i < 5; i++) {
+                const nextTs = parseTS(bufferedMessages[i].ts)
+                if (currentTs.time === nextTs.time) {
+                    nextTs.index.should.equal(currentTs.index + 1)
+                } else {
+                    nextTs.index.should.equal(0)
+                }
+                currentTs = nextTs
+            }
+        })
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/2361

## Description

Ensures device agent log messages get a properly formatted `ts` property when stored in the local buffer.

Adds some tests for this behaviour.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
