### PR TITLE
Fix starting agent in dev mode without existing snapshot locally

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -220,6 +220,7 @@ class Agent {
             let updateSettings = false
             if (this.currentState === 'unknown' && inhibitUpdates && !this.currentSnapshot && !this.currentProject && newState.project) {
                 info('Developer Mode: no flows found - updating to latest snapshot')
+                this.currentProject = newState.project
                 updateSnapshot = true
                 updateSettings = true
             } else if (inhibitUpdates === false) {


### PR DESCRIPTION
## Description

If the agent is started without a local snapshot, calls home, finds it is meant to be in dev mode it retrieves the current snapshot. However it wasn't updating its local record of the instance it was attached to, which lead to NR starting without a full configuration for the project nodes.

This fixes that.