### PR TITLE
Fix nr-theme source path

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -218,7 +218,9 @@ class Launcher {
 
     async writeThemeFiles () {
         info('Updating theme files')
-        const sourceDir = path.join(__dirname, '..', 'node_modules', '@flowforge', 'nr-theme')
+        const sourceDir1 = path.join(__dirname, '..', 'node_modules', '@flowforge', 'nr-theme')
+        const sourceDir2 = path.join(__dirname, '..', 'node_modules', '@flowforge', 'nr-theme')
+        const sourceDir = existsSync(sourceDir1) ? sourceDir1 : sourceDir2
         const targetDir = path.join(this.projectDir, 'node_modules', '@flowforge', 'nr-theme')
         try {
             if (!existsSync(sourceDir)) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -219,7 +219,7 @@ class Launcher {
     async writeThemeFiles () {
         info('Updating theme files')
         const sourceDir1 = path.join(__dirname, '..', 'node_modules', '@flowforge', 'nr-theme')
-        const sourceDir2 = path.join(__dirname, '..', 'node_modules', '@flowforge', 'nr-theme')
+        const sourceDir2 = path.join(__dirname, '..', '..', 'nr-theme')
         const sourceDir = existsSync(sourceDir1) ? sourceDir1 : sourceDir2
         const targetDir = path.join(this.projectDir, 'node_modules', '@flowforge', 'nr-theme')
         try {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Search path for nr-theme doesn't check if nr-theme is a peer-install to flowforge-device-agent

e.g.


node_modules/@flowforge/flowforge-device-agent
node_modules/@flowforge/flowforge-device-agent/node_modules/@flowforge/nr-theme

vs

node_modules/@flowforge/flowforge-device-agent
node_modules/@flowforge/nr-theme



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

