### PR TITLE
Ensure agent handles first run without currentMode set

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -153,9 +153,12 @@ class Agent {
         // for Node-RED were changed vs the current snapshot on the forge platform.
         // If they differ, we flag that a reload of the snapshot is required.
         if (newState !== null && newState.mode && newState.mode !== this.currentMode) {
-            ['developer', 'autonomous'].includes(newState.mode) || (newState.mode = 'autonomous')
-            const modeChanged = this.currentMode !== newState.mode
-            if (modeChanged) {
+            if (!['developer', 'autonomous'].includes(newState.mode)) {
+                newState.mode = 'autonomous'
+            }
+            if (!this.currentMode) {
+                this.currentMode = newState.mode
+            } else if (this.currentMode !== newState.mode) {
                 this.currentMode = newState.mode
                 if (newState.mode === 'developer') {
                     info('Enabling developer mode')

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -117,12 +117,8 @@ class Launcher {
 
     async readFlow () {
         debug(`Reading flows file: ${this.files.flows}`)
-        try {
-            const flows = await fs.readFile(this.files.flows, 'utf8')
-            return JSON.parse(flows)
-        } catch (error) {
-            console.error(error)
-        }
+        const flows = await fs.readFile(this.files.flows, 'utf8')
+        return JSON.parse(flows)
     }
 
     async writeCredentials () {


### PR DESCRIPTION
## Description

When running the device agent for the first time, its internal state didn't have `currentMode` set, which was interpreted to mean it had a local snapshot to compare against the remote flows - leading to the error in #134 

This is an alternative fix to #135 as it ensures the internal state is properly maintained.