### PR TITLE
Device Node-RED app environment variables: allow controllable propagation of env set to process to Node-RED app

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -260,7 +260,10 @@ class Launcher {
             await this.writeThemeFiles()
         }
 
-        const env = Object.assign({}, this.snapshot.env)
+        const filter_env = (env) =>
+            Object.entries(env).reduce((acc, [key, value]) =>
+                key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
+        const env = Object.assign({}, this.snapshot.env, filter_env(process.env))
         if (this.settings?.env) {
             Object.assign(env, this.settings?.env)
         }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -260,10 +260,15 @@ class Launcher {
             await this.writeThemeFiles()
         }
 
-        const filter_env = (env) =>
+        const filterEnv = (env) =>
             Object.entries(env).reduce((acc, [key, value]) =>
-                key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
-        const env = Object.assign({}, this.snapshot.env, filter_env(process.env))
+                key.startsWith('FORGE') ? acc : { ...acc, [key]: value }, {})
+
+        // According to https://github.com/flowforge/flowforge-nr-launcher/pull/145,
+        // and in order to keep this feature coherent between launchers,
+        // setting FORGE_EXPOSE_HOST_ENV on the container unlocks the host env propagation.
+        const env = Object.assign({}, this.snapshot.env,
+            process.env.FORGE_EXPOSE_HOST_ENV ? filterEnv(process.env) : {})
         if (this.settings?.env) {
             Object.assign(env, this.settings?.env)
         }


### PR DESCRIPTION
## Description

This is the consequent feature request based on similar in [nr-launcher](https://github.com/flowforge/flowforge-nr-launcher/issues/144).

### Environment variables, sources
In the environment that the Node-RED process operates, there are following sources for the environmental variables:

1. Variables set on the snapshot.
3. Variables that come into play when the Device instance is deployed via a container orchestrator (dynamically provisioned).

### Share env variables to software running with Node-RED
To forward environment variables to Node-RED (as well as software solutions running in Node-RED), we need to imbue the launcher with the ability to augment the application's environment with env from source 3 - e.g. those that are set on `process.env`. 

### Way to share env
Instead of the usual [way that Node-RED process will assume env](https://github.com/elenaviter/flowforge-device-agent/blob/917231bf7c0e458b847201069e8aa278482c8f4c/lib/launcher.js#L263-L266) includes:
- env set on Snapshot
- env with FF related project identification needed for Node-RED to communicate to storage via storage plugin

E.g. instead
```javascript
const env = Object.assign({}, this.snapshot.env)
if (this.settings?.env) {
    Object.assign(env, this.settings?.env)
}
```

We propose to propagate also `process.env`, while filter it to exclude variables starting with "FORGE", which stands for servicing FORGE secrets:
```javascript
const filter_env = (env) =>
    Object.entries(env).reduce((acc, [key, value]) =>
        key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
const env = Object.assign({}, this.snapshot.env, filter_env(process.env))
if (this.settings?.env) {
    Object.assign(env, this.settings?.env)
}
```

## Related Issue(s)

[Device's Node-RED environment variables: allow controllable propagation of env set to Node-RED process with the hosting operators](https://github.com/flowforge/flowforge-device-agent/issues/145)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

