### PR TITLE
Allow use of private CA for HTTPS certs

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -176,7 +176,7 @@ class EditorTunnel {
                         throwErrors: false
                     }
                     if (thisTunnel.localProtocol === 'https') {
-                        options.https = { rejectUnauthorized: true }
+                        options.https = { rejectUnauthorized: false }
                     }
                     got(fullUrl, options).then(response => {
                         // debug(`proxy [${request.method}] ${fullUrl} : sending response: status ${response.statusCode}`)


### PR DESCRIPTION
fixes #149

## Description

<!-- Describe your changes in detail -->
Allow device editor mode to access editor when using self signed certs (or not signed by a public CA)

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #149

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

