### PR TITLE
Use local TZ env var else use timeZone from settings

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -285,6 +285,10 @@ class Launcher {
             Object.assign(env, this.settings?.env)
         }
 
+        // Use local timezone if set, else use one from snapshot settings
+        // this will be ignored on Windows as it does not use the TZ env var
+        env.TZ = process.env.TZ ? process.env.TZ : this.settings.settings.timeZone
+
         info('Starting Node-RED')
         const appEnv = env
         const processArgs = [

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -287,7 +287,7 @@ class Launcher {
 
         // Use local timezone if set, else use one from snapshot settings
         // this will be ignored on Windows as it does not use the TZ env var
-        env.TZ = process.env.TZ ? process.env.TZ : this.settings.settings.timeZone
+        env.TZ = process.env.TZ ? process.env.TZ : this.settings?.settings?.timeZone
 
         info('Starting Node-RED')
         const appEnv = env


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Ensure local TZ env var is propagated to the NR instance, else use the one from the snapshot settings

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://community.flowforge.com/t/some-repeat-interval-options-for-inject-node-not-working-in-flowforge/188/6

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

