### PR TITLE
Fix device running or reporting old snapshot id/name

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -53,14 +53,27 @@ class Agent {
                     this.currentMode = config.mode || 'autonomous'
                     this.config.licensed = config.licensed || null
                 }
-                info(`Instance      : ${this.currentProject || 'unknown'}`)
-                info(`Snapshot      : ${this.currentSnapshot?.id || 'none'}`)
-                info(`Settings      : ${this.currentSettings?.hash || 'none'}`)
-                info(`Operation Mode: ${this.currentMode || 'unknown'}`)
-                info(`Licensed      : ${this.config.licensed === null ? 'unknown' : this.config.licensed ? 'yes' : 'no'}`)
+                this.printAgentStatus()
             } catch (err) {
                 warn(`Invalid project file: ${this.projectFilePath}`)
             }
+        }
+    }
+
+    printAgentStatus () {
+        info('Configuration :-')
+        info(`  * Instance         : ${this.currentProject || 'unknown'}`)
+        info(`  * Snapshot         : ${this.currentSnapshot?.id || 'none'}`)
+        info(`  * Settings         : ${this.currentSettings?.hash || 'none'}`)
+        info(`  * Operation Mode   : ${this.currentMode || 'unknown'}`)
+        info(`  * Licensed         : ${this.config.licensed === null ? 'unknown' : this.config.licensed ? 'yes' : 'no'}`)
+        if (typeof this.currentSettings?.env === 'object') {
+            info('Environment :-')
+            info(`  * FF_SNAPSHOT_ID   : ${this.currentSettings.env.FF_SNAPSHOT_ID || ''}`)
+            info(`  * FF_SNAPSHOT_NAME : ${this.currentSettings.env.FF_SNAPSHOT_NAME || ''}`)
+            info(`  * FF_DEVICE_ID     : ${this.currentSettings.env.FF_DEVICE_ID || ''}`)
+            info(`  * FF_DEVICE_NAME   : ${this.currentSettings.env.FF_DEVICE_NAME || ''}`)
+            info(`  * FF_DEVICE_TYPE   : ${this.currentSettings.env.FF_DEVICE_TYPE || ''}`)
         }
     }
 
@@ -382,9 +395,7 @@ class Agent {
                 if (this.currentSnapshot?.id) {
                     try {
                         // There is a new snapshot/settings to use
-                        info(`Instance: ${this.currentProject || 'unknown'}`)
-                        info(`Snapshot: ${this.currentSnapshot.id}`)
-                        info(`Settings: ${this.currentSettings?.hash || 'none'}`)
+                        this.printAgentStatus() // provide info update to console
                         await this.saveProject()
                         this.launcher = Launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                         await this.launcher.writeConfiguration()

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -192,11 +192,39 @@ class Agent {
                         // create a temporary launcher to read the current snapshot on disk
                         _launcher = Launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                     }
-                    const modules = (await _launcher.readPackage())?.modules
-                    const flows = await _launcher.readFlow()
-                    const diskSnapshot = { flows, modules }
                     forgeSnapshot = await this.httpClient.getSnapshot()
-                    newState.reloadSnapshot = utils.compareNodeRedData(forgeSnapshot, diskSnapshot) === false
+                    // before checking for changed flows etc, check if the snapshot on disk is the same as the snapshot on the forge platform
+                    // if it has changed, we need to reload the snapshot from the forge platform
+                    if (forgeSnapshot?.id !== _launcher.snapshot?.id) {
+                        info('Local snapshot differs from snapshot on the forge platform')
+                        newState.reloadSnapshot = true
+                    }
+
+                    // next check the key system environment variables match
+                    if (newState.reloadSnapshot !== true) {
+                        if (typeof forgeSnapshot?.env === 'object' && typeof _launcher.snapshot?.env === 'object') {
+                            const checkMatch = (key) => {
+                                return (forgeSnapshot.env[key] || null) === (_launcher.snapshot.env[key] || null)
+                            }
+                            const matchOk = checkMatch('FF_SNAPSHOT_ID') && checkMatch('FF_SNAPSHOT_NAME') && checkMatch('FF_DEVICE_ID') && checkMatch('FF_DEVICE_NAME') && checkMatch('FF_DEVICE_TYPE')
+                            if (matchOk === false) {
+                                info('Local snapshot predefined environment variables differ from snapshot on the forge platform')
+                                newState.reloadSnapshot = true
+                            }
+                        }
+                    }
+
+                    if (newState.reloadSnapshot !== true) {
+                        try {
+                            const modules = (await _launcher.readPackage())?.modules
+                            const flows = await _launcher.readFlow()
+                            const diskSnapshot = { flows, modules }
+                            newState.reloadSnapshot = utils.compareNodeRedData(forgeSnapshot, diskSnapshot) === false
+                        } catch (error) {
+                            info('An error occurred while attempting to read flows & package file from disk')
+                            newState.reloadSnapshot = true
+                        }
+                    }
                     if (newState.reloadSnapshot) {
                         info('Local flows have changed. Restoring current snapshot')
                     } else {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -209,7 +209,7 @@ class Agent {
                     // before checking for changed flows etc, check if the snapshot on disk is the same as the snapshot on the forge platform
                     // if it has changed, we need to reload the snapshot from the forge platform
                     if (forgeSnapshot?.id !== _launcher.snapshot?.id) {
-                        info('Local snapshot differs from snapshot on the forge platform')
+                        info('Local snapshot ID differs from the snapshot on the forge platform')
                         newState.reloadSnapshot = true
                     }
 
@@ -221,7 +221,7 @@ class Agent {
                             }
                             const matchOk = checkMatch('FF_SNAPSHOT_ID') && checkMatch('FF_SNAPSHOT_NAME') && checkMatch('FF_DEVICE_ID') && checkMatch('FF_DEVICE_NAME') && checkMatch('FF_DEVICE_TYPE')
                             if (matchOk === false) {
-                                info('Local snapshot predefined environment variables differ from snapshot on the forge platform')
+                                info('Local environment variables differ from the snapshot on the forge platform')
                                 newState.reloadSnapshot = true
                             }
                         }
@@ -232,7 +232,11 @@ class Agent {
                             const modules = (await _launcher.readPackage())?.modules
                             const flows = await _launcher.readFlow()
                             const diskSnapshot = { flows, modules }
-                            newState.reloadSnapshot = utils.compareNodeRedData(forgeSnapshot, diskSnapshot) === false
+                            const changes = utils.compareNodeRedData(forgeSnapshot, diskSnapshot) === false
+                            if (changes) {
+                                info('Local flows differ from the snapshot on the forge platform')
+                                newState.reloadSnapshot = true
+                            }
                         } catch (error) {
                             info('An error occurred while attempting to read flows & package file from disk')
                             newState.reloadSnapshot = true

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -343,6 +343,11 @@ class Agent {
                     if (this.currentSettings === null) {
                         updateSettings = true
                     }
+                    // If the snapshot is to be updated, the settings must also be updated
+                    // this is because snapshot includes special, platform defined environment variables e.g. FF_SNAPSHOT_ID
+                    if (updateSnapshot === true) {
+                        updateSettings = true
+                    }
                 }
             }
             if (!skipToUpdate && !updateSnapshot && !updateSettings) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -239,8 +239,11 @@ class Agent {
             }
         }
 
-        // Flag to inhibit updates if we are in developer mode
+        /** A flag to inhibit updates if we are in developer mode */
         const inhibitUpdates = this.currentMode === 'developer'
+
+        /** A flag to indicate execution should skip to the update step */
+        const skipToUpdate = newState?.reloadSnapshot === true
 
         if (newState === null) {
             // The agent should not be running (bad credentials/device details)
@@ -255,7 +258,7 @@ class Agent {
                 this.currentState = 'stopped'
                 this.updating = false
             }
-        } else if (inhibitUpdates === false && newState.project === null) {
+        } else if (!skipToUpdate && inhibitUpdates === false && newState.project === null) {
             if (this.currentProject) {
                 debug('Removed from project')
             }
@@ -283,7 +286,7 @@ class Agent {
             await this.saveProject()
             this.currentState = 'stopped'
             this.updating = false
-        } else if (inhibitUpdates === false && newState.snapshot === null) {
+        } else if (!skipToUpdate && inhibitUpdates === false && newState.snapshot === null) {
             // Snapshot removed, but project still active
             if (this.currentSnapshot) {
                 debug('Active snapshot removed')
@@ -342,7 +345,7 @@ class Agent {
                     }
                 }
             }
-            if (!updateSnapshot && !updateSettings) {
+            if (!skipToUpdate && !updateSnapshot && !updateSettings) {
                 // Nothing to update.
                 // Start the launcher with the current config, Snapshot & settings
                 if (!this.launcher && this.currentSnapshot) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,7 +25,7 @@ class Agent {
         this.updating = false
         this.queuedUpdate = null
         // Track the local state of the agent. Start in 'unknown' state so
-        // that the first MQTT checkin will trigger a response
+        // that the first MQTT check-in will trigger a response
         this.currentState = 'unknown'
         // ensure licensed property is present (default to null)
         if (Object.prototype.hasOwnProperty.call(this.config, 'licensed') === false) {


### PR DESCRIPTION
## Description


This PR addresses several issues found while debugging the reported problem.

NOTE: None of the work here involved messing with the device files. The state of the device and its files were all a result of actions taken in the forge application.  I feel this is important to point out because as it stands, it is possible to get the device to crash and into odd states.

The issues encountered...

### problem 1 - device running snapshot of deleted instance
Device active/target snapshot get populated in checkin code
device reports it is on old snapshot & that matches 
checkin code did not check that the activeSnapshots project matched the device current project

### problem 2 - snapshot table is not cleaned - holds snapshots from deleted instances
When device checks in, its reported snapshot is found and the device objects active/target snapshot are populated meaning the device passes its checkin & does not instruct an update.

NOTE: No work was done to delete the old snapshots, only to mitigate the problem. A separate issue will be raised detailing thoughts and care points around this.  

### problem 3
Even if we force a DeviceUpdate, it just passes the exact same settings due to the snapshot table having old entries

### problem 4
Once we do get the device to clean up, switching between dev/autonomous mode caused a crash due to missing files
```
[AGENT] 09/08/2023 09:47:27 [info] Cleaning instance directory
[AGENT] 09/08/2023 09:47:50 [info] Enabling developer mode
[AGENT] 09/08/2023 09:47:51 [info] Enabling remote editor access
[AGENT] 09/08/2023 09:47:51 [info] No running Node-RED instance, not starting editor
[AGENT] 09/08/2023 09:47:56 [info] Enabling remote editor access
[AGENT] 09/08/2023 09:47:56 [info] No running Node-RED instance, not starting editor
[Error: ENOENT: no such file or directory, open 'C:\opt\flowforge-device\project\flows.json'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\opt\\flowforge-device\\project\\flows.json'
}
```

### problem 5
when the agent determines a new snapshot is available, we dont instruct it to grab new settings.
Since some env vars are computed by the platform (e.g. FF_SNAPSHOT_ID/NAME) we must also instruct
the agent to refresh its settings.

### The work in this PR

#### 1: [Improve detection of changes after dev mode](https://github.com/flowforge/flowforge-device-agent/commit/385e5ede2844d21364fad004e3f6a60135fc5b7c)

Here, instead of doing a flow comparison (potentially costly operation & potentially pointless if the new snapshot flows match the old snapshot flows), the checks are broken down into 3 individual parts (each increasing in processing requirements)
* check snapshot IDs for change
* check system env vars for change (e.g. has FF_SNAPSHOT_ID changed?)
* check flows for change

If any have changed, we set a flag to indicate a reload is necessary

#### 2: [skip to updates when change detected](https://github.com/flowforge/flowforge-device-agent/commit/edce449b274e1787770b84c4c0345c542d28d048)

Under certain circumstances, it is possible receive an update WITHOUT a snapshot. In this case, the `setState` was entering the middle of the state machine and NOT getting to the important part where updates are applied.

#### 3: [ensure settings update if snapshot needs update](https://github.com/flowforge/flowforge-device-agent/commit/29f9ec01fb48f322c1deac218272fea3ba70b3c4)

Since FF_SNAPSHOT_ID was added we _should_ **always** reload the settings when the snapshot changes.
Failing to do so means we hold stale info in the env vars.

#### 4: [improve feedback info: include snapshot id/name](https://github.com/flowforge/flowforge-device-agent/commit/5313a584d743ac605e6c7fa6d5652b5f0991681e)

Specifically 
- deduplicate the 2 places where Instance, Snapshot, Project etc are logged to console into a common routine. 
- adds the FF_* env vars to the log output (so user can SEE when the env vars are out of step with the config)


#### 5: [update tests](https://github.com/flowforge/flowforge-device-agent/commit/5313a584d743ac605e6c7fa6d5652b5f0991681e)

2 new tests added
- reloads latest snapshot from platform when switching off developer mode (if snapshot ID changed)
- reloads latest snapshot from platform when switching off developer mode (if platform env vars are modified)

Additionally: Fixes several failing tests due to now ALWAYS reloading settings if the snapshot has changed (see item 3 above)


## Related Issue(s)

#132 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

