### PR TITLE
Increase snapshot download timeout

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -31,7 +31,7 @@ class HTTPClient {
 
     async getSnapshot () {
         try {
-            return await this.client.get('live/snapshot').json()
+            return await this.client.get('live/snapshot', {timeout: {request: 20000 }}).json()
         } catch (err) {
             warn(`Problem getting snapshot: ${err.toString()}`)
             debug(err)

--- a/lib/http.js
+++ b/lib/http.js
@@ -31,7 +31,7 @@ class HTTPClient {
 
     async getSnapshot () {
         try {
-            return await this.client.get('live/snapshot', { timeout: { request: 20000 } }).json()
+            return await this.client.get('live/snapshot', { timeout: { request: 30000 } }).json()
         } catch (err) {
             warn(`Problem getting snapshot: ${err.toString()}`)
             debug(err)

--- a/lib/http.js
+++ b/lib/http.js
@@ -31,7 +31,7 @@ class HTTPClient {
 
     async getSnapshot () {
         try {
-            return await this.client.get('live/snapshot', {timeout: {request: 20000 }}).json()
+            return await this.client.get('live/snapshot', { timeout: { request: 20000 } }).json()
         } catch (err) {
             warn(`Problem getting snapshot: ${err.toString()}`)
             debug(err)

--- a/test/unit/frontend/routes.spec.js
+++ b/test/unit/frontend/routes.spec.js
@@ -14,7 +14,7 @@ describe('Device Agent Web Server Routes (API)', function () {
     let configDir
 
     const got = Got.extend({
-        prefixUrl: 'http://localhost:1879',
+        prefixUrl: 'http://127.0.0.1:1879',
         throwHttpErrors: false
     })
 


### PR DESCRIPTION
fix for #162

## Description

<!-- Describe your changes in detail -->
Slow network is causing larger snapshots to timeout when being downloaded.

Doubled the download time just for snapshots, might still want to look at retry on failure.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#162

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

