### PR TITLE
Ensure snapshot download retries

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -206,6 +206,11 @@ class Agent {
                         _launcher = Launcher.newLauncher(this.config, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                     }
                     forgeSnapshot = await this.httpClient.getSnapshot()
+                    if (!forgeSnapshot) {
+                        // failed to download snapshot
+                        this.updating = false
+                        return
+                    }
                     // before checking for changed flows etc, check if the snapshot on disk is the same as the snapshot on the forge platform
                     // if it has changed, we need to reload the snapshot from the forge platform
                     if (forgeSnapshot?.id !== _launcher.snapshot?.id) {


### PR DESCRIPTION
part of #162

## Description

<!-- Describe your changes in detail -->
If the device agent fails to download the snapshot it currently doesn't retry

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#162

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

