### PR TITLE
Do not attempt editor reconnect if platform tells us No Tunnel

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -202,21 +202,29 @@ class EditorTunnel {
             })
         }
         socket.on('close', async (code, reason) => {
+            if (Buffer.isBuffer(reason)) {
+                reason = reason.toString()
+            }
             // The socket connection to the platform has closed
             info(`Editor tunnel closed code=${code} reason=${reason}`)
             socket.removeAllListeners()
             this.socket = null
             clearTimeout(this.reconnectTimeout)
-
-            // Assume we need to be reconnecting. If this close is due
-            // to a request from the platform to turn off editor access,
-            // .close will get called
-            const reconnectDelay = this.reconnectDelay
-            // Bump the delay for next time... 500ms, 1.5s, 4.5s, 10s 10s 10s...
-            this.reconnectDelay = Math.min(this.reconnectDelay * 3, 10000)
-            this.reconnectTimeout = setTimeout(() => {
-                this.connect()
-            }, reconnectDelay)
+            if (reason !== 'No tunnel') {
+                // Assume we need to be reconnecting. If this close is due
+                // to a request from the platform to turn off editor access,
+                // .close will get called
+                const reconnectDelay = this.reconnectDelay
+                // Bump the delay for next time... 500ms, 1.5s, 4.5s, 10s 10s 10s...
+                this.reconnectDelay = Math.min(this.reconnectDelay * 3, 10000)
+                this.reconnectTimeout = setTimeout(() => {
+                    this.connect()
+                }, reconnectDelay)
+            } else {
+                // A 'No tunnel' response means the platform doesn't think
+                // we should be connecting - so no point retrying
+                this.close(code, reason)
+            }
         })
         socket.on('error', (err) => {
             warn(`Editor tunnel error: ${err}`)

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -210,7 +210,11 @@ class EditorTunnel {
             socket.removeAllListeners()
             this.socket = null
             clearTimeout(this.reconnectTimeout)
-            if (reason !== 'No tunnel') {
+            // Pre 1.12, FF returned '1008/No Tunnel' - but 1008 was also used
+            // for other scenarios, so we have to check both code and reason text.
+            // 1.12+ returns '4004/No Tunnel' - where 4004 is only used for this
+            // scenario so we don't have to worry about the text (which could change in the future).
+            if ((code === 1008 && reason !== 'No tunnel') || code !== 4004) {
                 // Assume we need to be reconnecting. If this close is due
                 // to a request from the platform to turn off editor access,
                 // .close will get called
@@ -221,7 +225,7 @@ class EditorTunnel {
                     this.connect()
                 }, reconnectDelay)
             } else {
-                // A 'No tunnel' response means the platform doesn't think
+                // A 4004/'No tunnel' response means the platform doesn't think
                 // we should be connecting - so no point retrying
                 this.close(code, reason)
             }


### PR DESCRIPTION
Fixes #168 

## Description

If the connection is too slow to create, the platform will close the connection and discard the session token. The device agent just sees a connection drop so automatically retries.

But as the token has been discarded, it isn't going to succeed - but keeps trying anyway.

This fix checks the reason code the platform provided (if any). The 'No tunnel' reason tells us the platform doesn't have a matching session token so there is no point retrying.