### PR TITLE
Fix for got v12

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -2,7 +2,7 @@ const settings = require('./settings.json')
 const editorTheme = settings.editorTheme || {}
 const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
-const { default: got } = require('got')
+const { default: got } = import('got')
 const { existsSync, readFileSync } = require('fs')
 
 settings.editorTheme.header = settings.editorTheme.header || {}


### PR DESCRIPTION
fixes #173

## Description

<!-- Describe your changes in detail -->
Node-RED v3.1.0 now depends on got v12.6.0 which is a ESM only package

When got is used in the `settings.js` generated by the agent it loads it from the NR dependencies, this broke with the move from NR 3.0.2 to NR 3.1.0

Will need to ensure clients update device agent before moving instances to 3.1.0 stacks or using Devices attached to Applications (which default to NR:latest) see flowforge/flowforge#2802

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#173

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

